### PR TITLE
Netlifyへデプロイするワークフローでnpm ciを使うようにした

### DIFF
--- a/.github/workflows/deploy_netlify.yml
+++ b/.github/workflows/deploy_netlify.yml
@@ -19,7 +19,7 @@ jobs:
           node-version: 18.x
           cache: 'npm'
       - name: Install dependencies
-        run: npm install
+        run: npm ci
       - name: Install Netlify CLI
         run: npm install -g netlify-cli
       - name: Deploy to Netlify


### PR DESCRIPTION
## 概要
Netlifyへデプロイするワークフローでnpm ciを使うようにした。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - ネットリファイへのデプロイプロセスにおいて、依存関係をインストールするコマンドを`npm install`から`npm ci`に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->