### PR TITLE
トップページのモックを追加した

### DIFF
--- a/app/contexts/user/sns-user-context.tsx
+++ b/app/contexts/user/sns-user-context.tsx
@@ -1,0 +1,7 @@
+import { createContext } from "react";
+import FF14SnsUser from "../../libraries/user/ff14-sns-user";
+
+/**
+ * SNSのユーザーコンテキスト。
+ */
+export const SnsUserContext = createContext<FF14SnsUser | null>(null);

--- a/app/contexts/user/sns-user-provider.tsx
+++ b/app/contexts/user/sns-user-provider.tsx
@@ -1,0 +1,24 @@
+import { ReactNode } from "react"
+import FF14SnsUser from "../../libraries/user/ff14-sns-user";
+import { SnsUserContext } from "./sns-user-context";
+
+/**
+ * SNSのユーザープロバイダー。
+ * @param children 子要素。
+ * @param snsUser SNSのユーザー。
+ * @returns SNSのユーザープロバイダー。
+ */
+const SnsUserProvider = ({
+    children,
+    snsUser,
+} : {
+    children: ReactNode,
+    snsUser: FF14SnsUser,
+}) => {
+    return (
+        <SnsUserContext.Provider value={snsUser}>
+            { children }
+        </SnsUserContext.Provider>
+    )
+}
+export default SnsUserProvider;

--- a/app/contexts/user/use-sns-user.tsx
+++ b/app/contexts/user/use-sns-user.tsx
@@ -1,0 +1,14 @@
+import { useContext } from "react";
+import { SnsUserContext } from "./sns-user-context";
+
+/**
+ * SNSのユーザーを取得する。
+ * @returns SNSのユーザー。
+ */
+export default function useSnsUser() {
+    const context = useContext(SnsUserContext);
+    if (!context) {
+        throw new Error("useUserはSnsUserProviderの子コンポーネントでのみ使用できます。");
+    }
+    return context;
+}

--- a/app/cookies.server.ts
+++ b/app/cookies.server.ts
@@ -9,3 +9,13 @@ export const userAuthenticationCookie = createCookie("user-authentication", {
     sameSite: "lax",
     maxAge: 2_592_000,
 });
+
+/**
+ * 新規投稿した投稿のIDを保持するCookie。
+ */
+export const newlyPostedPostCookie = createCookie("newly-posted-post", {
+    secure: true,
+    httpOnly: true,
+    sameSite: "lax",
+    maxAge: 3_600,
+});

--- a/app/dependency-injector/get-load-context.ts
+++ b/app/dependency-injector/get-load-context.ts
@@ -7,6 +7,7 @@ import UserAuthenticationAction from "../actions/authentication/user-authenticat
 import IUserAuthenticator from "../libraries/authentication/i-user-authenticator";
 import UserRegistrationAction from "../actions/authentication/user-registration-action";
 import IUserRegistrar from "../libraries/authentication/i-user-registrar";
+import LatestPostsLoader from "../loaders/post/latest-posts-loader";
 
 // ユーザー登録を行うためのクラスを生成する。
 const userAccountManager = new FirebaseUserAccountManager();
@@ -21,10 +22,14 @@ const userAuthenticationAction = new UserAuthenticationAction(userAuthenticator)
 const authenticatedUserProvider = new FirebaseAuthenticatedUserProvider();
 const ff14SnsUserLoader = new FF14SnsUserLoader(authenticatedUserProvider);
 
+// 最新の投稿を取得するためのクラスを生成する。
+const latestPostsLoader = new LatestPostsLoader();
+
 export const appLoadContext: AppLoadContext = {
     userRegistrationAction,
     userAuthenticationAction,
     ff14SnsUserLoader,
+    latestPostsLoader,
 };
 
 /**

--- a/app/loaders/post/latest-posts-loader.ts
+++ b/app/loaders/post/latest-posts-loader.ts
@@ -1,0 +1,29 @@
+import PostContent from "../../models/post/post-content";
+
+/**
+ * 最新の投稿を取得するローダー。
+ */
+export default class LatestPostsLoader {
+    /**
+     * 最新の投稿を取得する。
+     * @param id 投稿ID。
+     * @returns 最新の投稿。
+     */
+    public async getLatestPosts(id: string): Promise<PostContent[]> {
+        const idNumber = Number(id);
+        const postContents: PostContent[] = Array.from({
+            length: 10,
+        }, (_, i) => {
+            const incrementedId = i + 1 + idNumber;
+
+            return ({
+                id: incrementedId.toString(),
+                releaseVersion: "5.5",
+                tag: "考察",
+                createdAt: new Date(),
+                content: `これは${incrementedId}のテストです。これは${incrementedId}のテストです。これは${incrementedId}のテストです。これは${incrementedId}のテストです。これは${incrementedId}のテストです。\nこれは${incrementedId}のテストです。これは${incrementedId}のテストです。これは${incrementedId}のテストです。`,
+            });
+        });
+        return postContents;
+    }
+}

--- a/app/loaders/post/latest-posts-loader.ts
+++ b/app/loaders/post/latest-posts-loader.ts
@@ -10,18 +10,25 @@ export default class LatestPostsLoader {
      * @returns 最新の投稿。
      */
     public async getLatestPosts(id: string): Promise<PostContent[]> {
-        const idNumber = Number(id);
+        const idNumber = Number(id) + 1;
         const postContents: PostContent[] = Array.from({
             length: 10,
         }, (_, i) => {
-            const incrementedId = i + 1 + idNumber;
+            const incrementedId = i + idNumber;
+            const content = `
+                これはポスト${incrementedId}のテストです。\n
+                これはポスト${incrementedId}のテストです。\n
+                これはポスト${incrementedId}のテストです。\n
+                これはポスト${incrementedId}のテストです。\n
+                これはポスト${incrementedId}のテストです。\n
+            `;
 
             return ({
                 id: incrementedId.toString(),
                 releaseVersion: "5.5",
                 tag: "考察",
                 createdAt: new Date(),
-                content: `これは${incrementedId}のテストです。これは${incrementedId}のテストです。これは${incrementedId}のテストです。これは${incrementedId}のテストです。これは${incrementedId}のテストです。\nこれは${incrementedId}のテストです。これは${incrementedId}のテストです。これは${incrementedId}のテストです。`,
+                content: content,
             });
         });
         return postContents;

--- a/app/models/common/entity.ts
+++ b/app/models/common/entity.ts
@@ -1,0 +1,14 @@
+/**
+ * エンティティのベースインターフェース。
+ */
+export default interface Entity {
+    /**
+     * ID。
+     */
+    id: string;
+
+    /**
+     * 作成日時。
+     */
+    createdAt: Date;
+}

--- a/app/models/post/post-content.ts
+++ b/app/models/post/post-content.ts
@@ -1,0 +1,29 @@
+/**
+ * 投稿内容。
+ */
+export default interface PostContent {
+    /**
+     * 投稿ID。
+     */
+    id: string;
+
+    /**
+     * 投稿内容に含まれるリリースバージョン。
+     */
+    releaseVersion: string;
+
+    /**
+     * タグ。
+     */
+    tag: string;
+
+    /**
+     * 投稿日時。
+     */
+    createdAt: Date;
+
+    /**
+     * 投稿内容。
+     */
+    content: string;
+}

--- a/app/models/post/post-content.ts
+++ b/app/models/post/post-content.ts
@@ -1,12 +1,9 @@
+import Entity from '../common/entity';
+
 /**
  * 投稿内容。
  */
-export default interface PostContent {
-    /**
-     * 投稿ID。
-     */
-    id: string;
-
+export default interface PostContent extends Entity {
     /**
      * 投稿内容に含まれるリリースバージョン。
      */
@@ -16,11 +13,6 @@ export default interface PostContent {
      * タグ。
      */
     tag: string;
-
-    /**
-     * 投稿日時。
-     */
-    createdAt: Date;
 
     /**
      * 投稿内容。

--- a/app/routes/app._index/components/latest-post-time-line.tsx
+++ b/app/routes/app._index/components/latest-post-time-line.tsx
@@ -1,0 +1,20 @@
+import PostDisplay from "../../components/post-display";
+import PostContent from "../../../models/post/post-content";
+
+export default function LatestPostTimeLine({
+    postContents,
+}: {
+    postContents: PostContent[];
+}) {
+    return (
+        <div>
+            {postContents.map((postContent) => {
+                return (
+                    <div>
+                        <PostDisplay postContent={postContent} />
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/app/routes/app._index/components/latest-post-time-line.tsx
+++ b/app/routes/app._index/components/latest-post-time-line.tsx
@@ -1,6 +1,11 @@
 import PostDisplay from "../../components/post-display";
 import PostContent from "../../../models/post/post-content";
 
+/**
+ * 最新の投稿を表示するコンポーネント。
+ * @param postContents 全ての投稿。
+ * @returns 最新の投稿を表示するコンポーネント。
+ */
 export default function LatestPostTimeLine({
     postContents,
 }: {

--- a/app/routes/app._index/components/post-entry.tsx
+++ b/app/routes/app._index/components/post-entry.tsx
@@ -1,0 +1,17 @@
+import { Link } from "@remix-run/react";
+import useSnsUser from "../../../contexts/user/use-sns-user";
+
+/**
+ * 投稿エントリー。
+ * @returns 投稿エントリー。
+ */
+export default function PostEntry() {
+    const snsUser = useSnsUser();
+
+    return (
+        <Link to="app/post">
+            <p>{snsUser.name}</p>
+            <p>投稿</p>
+        </Link>
+    );
+}

--- a/app/routes/app._index/route.tsx
+++ b/app/routes/app._index/route.tsx
@@ -5,32 +5,30 @@ import { newlyPostedPostCookie } from "../../cookies.server";
 import { useLoaderData } from "@remix-run/react";
 import PostContent from "../../models/post/post-content";
 
+/**
+ * 最新の投稿を取得するローダー。
+ * ユーザーが投稿した直後の場合、ユーザーの投稿が最初に含まれる投稿を返す。
+ * @param request リクエスト。
+ * @param context コンテキスト。
+ * @returns 最新の投稿。
+ */
 export const loader = async ({
     request,
     context,
 }: LoaderFunctionArgs) => {
     const cookieHeader = request.headers.get("Cookie");
     const cookie = (await newlyPostedPostCookie.parse(cookieHeader)) || {};
-
-    const postContents: PostContent[] = Array.from({
-        length: 10,
-    }, (_, i) => {
-        const incrementedI = i + 1;
-
-        return ({
-            id: incrementedI.toString(),
-            releaseVersion: "5.5",
-            tag: "考察",
-            createdAt: new Date(),
-            content: `これは${incrementedI}のテストです。これは${incrementedI}のテストです。これは${incrementedI}のテストです。これは${incrementedI}のテストです。これは${incrementedI}のテストです。\nこれは${incrementedI}のテストです。これは${incrementedI}のテストです。これは${incrementedI}のテストです。`,
-        });
-    });
+    const postContents: PostContent[] = await context.latestPostsLoader.getLatestPosts("0");
     if (Object.keys(cookie).length > 0 && cookie.isPosted) {
         return json(postContents);
     }
     return json(postContents);
 }
 
+/**
+ * トップページのインデックス。
+ * @returns トップページのインデックス。
+ */
 export default function TopIndex() {
     const latestPostContents: PostContent[] = useLoaderData<typeof loader>().map((postContent) => ({
         ...postContent,

--- a/app/routes/app._index/route.tsx
+++ b/app/routes/app._index/route.tsx
@@ -1,7 +1,46 @@
-export default function Index() {
+import { LoaderFunctionArgs, json } from "@netlify/remix-runtime";
+import PostEntry from "./components/post-entry";
+import LatestPostTimeLine from "./components/latest-post-time-line";
+import { newlyPostedPostCookie } from "../../cookies.server";
+import { useLoaderData } from "@remix-run/react";
+import PostContent from "../../models/post/post-content";
+
+export const loader = async ({
+    request,
+    context,
+}: LoaderFunctionArgs) => {
+    const cookieHeader = request.headers.get("Cookie");
+    const cookie = (await newlyPostedPostCookie.parse(cookieHeader)) || {};
+
+    const postContents: PostContent[] = Array.from({
+        length: 10,
+    }, (_, i) => {
+        const incrementedI = i + 1;
+
+        return ({
+            id: incrementedI.toString(),
+            releaseVersion: "5.5",
+            tag: "考察",
+            createdAt: new Date(),
+            content: `これは${incrementedI}のテストです。これは${incrementedI}のテストです。これは${incrementedI}のテストです。これは${incrementedI}のテストです。これは${incrementedI}のテストです。\nこれは${incrementedI}のテストです。これは${incrementedI}のテストです。これは${incrementedI}のテストです。`,
+        });
+    });
+    if (Object.keys(cookie).length > 0 && cookie.isPosted) {
+        return json(postContents);
+    }
+    return json(postContents);
+}
+
+export default function TopIndex() {
+    const latestPostContents: PostContent[] = useLoaderData<typeof loader>().map((postContent) => ({
+        ...postContent,
+        createdAt: new Date(postContent.createdAt),
+    }));
+
     return (
-        <main>
-            <h2>Top</h2>
-        </main>
+        <div>
+            <PostEntry />
+            <LatestPostTimeLine postContents={latestPostContents} />
+        </div>
     );
 }

--- a/app/routes/app._index/route.tsx
+++ b/app/routes/app._index/route.tsx
@@ -2,8 +2,10 @@ import { LoaderFunctionArgs, json } from "@netlify/remix-runtime";
 import PostEntry from "./components/post-entry";
 import LatestPostTimeLine from "./components/latest-post-time-line";
 import { newlyPostedPostCookie } from "../../cookies.server";
-import { useLoaderData } from "@remix-run/react";
+import { useFetcher, useLoaderData } from "@remix-run/react";
 import PostContent from "../../models/post/post-content";
+import InfiniteScroll from "../components/infinite-scroll";
+import { useState } from "react";
 
 /**
  * 最新の投稿を取得するローダー。
@@ -30,15 +32,24 @@ export const loader = async ({
  * @returns トップページのインデックス。
  */
 export default function TopIndex() {
-    const latestPostContents: PostContent[] = useLoaderData<typeof loader>().map((postContent) => ({
+    const fetcher = useFetcher<typeof loader>();
+    const initialLatestPostContents: PostContent[] = useLoaderData<typeof loader>().map((postContent) => ({
         ...postContent,
         createdAt: new Date(postContent.createdAt),
     }));
+    const [latestPostContents, setLatestPostContents] = useState<PostContent[]>(initialLatestPostContents);
 
     return (
         <div>
-            <PostEntry />
-            <LatestPostTimeLine postContents={latestPostContents} />
+            <InfiniteScroll
+                fetcher={fetcher}
+                targetAddress="/app/latest-posts"
+                contents={latestPostContents}
+                setContents={setLatestPostContents}
+            >
+                <PostEntry />
+                <LatestPostTimeLine postContents={latestPostContents} />
+            </InfiniteScroll>
         </div>
     );
 }

--- a/app/routes/app.latest-posts.$id/route.tsx
+++ b/app/routes/app.latest-posts.$id/route.tsx
@@ -12,7 +12,7 @@ export const loader = async ({
     context,
     params,
 }: LoaderFunctionArgs) => {
-    if (params.id === undefined) return json([]);
+    if (params.id === undefined || !params.id) return json([]);
     const postId = params.id;
     const postContents: PostContent[] = await context.latestPostsLoader.getLatestPosts(postId);
     return json(postContents);

--- a/app/routes/app.latest-posts.$id/route.tsx
+++ b/app/routes/app.latest-posts.$id/route.tsx
@@ -1,0 +1,19 @@
+import { LoaderFunctionArgs, json } from "@netlify/remix-runtime";
+import PostContent from "../../models/post/post-content";
+
+/**
+ * 最新の投稿を取得するローダー。
+ * ユーザーが投稿した直後の場合、ユーザーの投稿が最初に含まれる投稿を返す。
+ * @param context コンテキスト。
+ * @param params パラメーター。
+ * @returns 最新の投稿。
+ */
+export const loader = async ({
+    context,
+    params,
+}: LoaderFunctionArgs) => {
+    if (params.id === undefined) return json([]);
+    const postId = params.id;
+    const postContents: PostContent[] = await context.latestPostsLoader.getLatestPosts(postId);
+    return json(postContents);
+}

--- a/app/routes/app/components/header.tsx
+++ b/app/routes/app/components/header.tsx
@@ -1,13 +1,9 @@
 import { Form } from "@remix-run/react";
-import FF14SnsUser from "../../../libraries/user/ff14-sns-user";
+import useSnsUser from "../../../contexts/user/use-sns-user";
 
-interface HeaderProps {
-    ff14SnsUser: FF14SnsUser;
-}
+export default function Header() {
+    const ff14SnsUser = useSnsUser();
 
-export default function Header({
-    ff14SnsUser
-}: HeaderProps) {
     return (
         <header>
             <h1>FF14 Header</h1>

--- a/app/routes/app/route.tsx
+++ b/app/routes/app/route.tsx
@@ -6,6 +6,10 @@ import { userAuthenticationCookie } from "../../cookies.server";
 import Header from "./components/header";
 import Footer from "./components/footer";
 
+/**
+ * トップページのメタ情報を取得する。
+ * @returns トップページのメタ情報。
+ */
 export const meta: MetaFunction = () => {
     return [
         { title: "FF14 SNS" },
@@ -13,6 +17,13 @@ export const meta: MetaFunction = () => {
     ];
 }
 
+/**
+ * FF14SNSのユーザーを取得するローダー。
+ * @param request リクエスト。
+ * @param context コンテキスト。
+ * @returns FF14SNSのユーザー。
+ * @throws ログインしていない場合、ログインページにリダイレクトする。
+ */
 export const loader = async ({
     request,
     context,
@@ -41,6 +52,12 @@ export const loader = async ({
     }
 }
 
+/**
+ * ログアウトするアクション。
+ * @param request リクエスト。
+ * @param context コンテキスト。
+ * @returns ログインページにリダイレクトする。
+ */
 export const action = async ({
     request,
     context,
@@ -75,17 +92,17 @@ export const action = async ({
     }
 }
 
-export default function App() {
-    const ff14SnsUserJson = useLoaderData<typeof loader>();
-    const ff14SnsUser: FF14SnsUser = {
-        name: ff14SnsUserJson.name,
-    };
+/**
+ * トップページ。
+ * @returns トップページ。
+ */
+export default function Top() {
+    const ff14SnsUser: FF14SnsUser = useLoaderData<typeof loader>();
 
     return (
         <main>
             <SnsUserProvider snsUser={ff14SnsUser}>
                 <Header />
-                <h1>FF14 SNS</h1>
                 <Outlet />
                 <Footer />
             </SnsUserProvider>

--- a/app/routes/app/route.tsx
+++ b/app/routes/app/route.tsx
@@ -1,6 +1,7 @@
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from "@netlify/remix-runtime";
 import { Outlet, useLoaderData } from "@remix-run/react";
 import FF14SnsUser from "../../libraries/user/ff14-sns-user";
+import SnsUserProvider from "../../contexts/user/sns-user-provider";
 import { userAuthenticationCookie } from "../../cookies.server";
 import Header from "./components/header";
 import Footer from "./components/footer";
@@ -82,10 +83,12 @@ export default function App() {
 
     return (
         <main>
-            <Header ff14SnsUser={ff14SnsUser} />
-            <h1>FF14 SNS</h1>
-            <Outlet />
-            <Footer />
+            <SnsUserProvider snsUser={ff14SnsUser}>
+                <Header />
+                <h1>FF14 SNS</h1>
+                <Outlet />
+                <Footer />
+            </SnsUserProvider>
         </main>
     );
 }

--- a/app/routes/components/infinite-scroll.tsx
+++ b/app/routes/components/infinite-scroll.tsx
@@ -1,0 +1,89 @@
+import { SerializeFrom } from "@netlify/remix-runtime";
+import { FetcherWithComponents } from "@remix-run/react";
+import { Dispatch, ReactNode, SetStateAction, useCallback, useEffect, useState } from "react";
+import Entity from "../../models/common/entity";
+
+/**
+ * 無限スクロール。
+ * @param children 子要素。
+ * @param fetcher フェッチャー。
+ * @param targetAddress フェッチするアドレス。
+ * @param contents 無限スクロールするコンテンツ。
+ * @param setContents 無限スクロールするコンテンツを設定する関数。
+ * @returns 無限スクロール。
+ */
+export default function InfiniteScroll<T extends Entity[]>({
+    children,
+    fetcher,
+    targetAddress,
+    contents,
+    setContents,
+}: {
+    children: ReactNode,
+    fetcher: FetcherWithComponents<SerializeFrom<T>>,
+    targetAddress: string,
+    contents: T,
+    setContents: Dispatch<SetStateAction<T>>,
+}) {
+    const [scrollPosition, setScrollPosition] = useState(0);
+    const [clientHeight, setClientHeight] = useState(0);
+    const updateScrollPosition = () => {
+        setScrollPosition(window.scrollY);
+        setClientHeight(window.innerHeight);
+    }
+
+    const [componentHeight, setComponentHeight] = useState<number | null>(null);
+    const componentRef = useCallback((node: HTMLElement | null) => {
+        if (node !== null) {
+            setComponentHeight(node.getBoundingClientRect().height);
+        }
+    }, [contents.length]);
+
+    useEffect(() => {
+        if (typeof window !== "undefined") {
+            window.addEventListener("scroll", updateScrollPosition);
+        }
+        return () => {
+            if (typeof window !== "undefined") {
+                window.removeEventListener("scroll", updateScrollPosition);
+            }
+        }
+    }, []);
+
+    const [shouldFetch, setShouldFetch] = useState(true);
+    useEffect(() => {
+        // データをフェッチするべきかどうかを判定する。
+        if (!shouldFetch || !componentHeight) return;
+        if (clientHeight + scrollPosition + 100 < componentHeight) return;
+        if (fetcher.state === "loading") return;
+
+        // データをフェッチする。
+        const lastId = contents[contents.length - 1].id;
+        fetcher.load(`${targetAddress}/${lastId}`);
+        setShouldFetch(false);
+    }, [scrollPosition, clientHeight, fetcher.state]);
+
+    useEffect(() => {
+        if (!fetcher.data) return;
+        if (!Array.isArray(fetcher.data)) return;
+
+        // データをフェッチするべきかどうかを判定する。
+        if (fetcher.data.length === 0) {
+            setShouldFetch(false);
+            return;
+        }
+
+        // データを追加する。
+        const data = fetcher.data as T;
+        if (data.length > 0) {
+            setContents((prevContents: T) => [...prevContents, ...data] as T);
+            setShouldFetch(true);
+        }
+    }, [fetcher.data]);
+
+    return (
+        <div ref={componentRef}>
+            {children}
+        </div>
+    );
+}

--- a/app/routes/components/post-display.tsx
+++ b/app/routes/components/post-display.tsx
@@ -1,4 +1,4 @@
-import { Form, Link, useFetcher } from "@remix-run/react";
+import { Link, useFetcher } from "@remix-run/react";
 import useSnsUser from "../../contexts/user/use-sns-user";
 import PostContent from "../../models/post/post-content";
 

--- a/app/routes/components/post-display.tsx
+++ b/app/routes/components/post-display.tsx
@@ -1,0 +1,75 @@
+import { Form, Link, useFetcher } from "@remix-run/react";
+import useSnsUser from "../../contexts/user/use-sns-user";
+import PostContent from "../../models/post/post-content";
+
+/**
+ * 投稿表示。
+ * @param postContent 投稿内容。
+ * @returns 投稿表示。
+ */
+export default function PostDisplay({
+    postContent,
+}: {
+    postContent: PostContent;
+}) {
+    const fetcher = useFetcher();
+    const reactionTypes = ["like", "love", "wow"];
+    const reactionNames = ["いいね", "ラブ", "ワオ！"];
+
+    const getPostTime = () => {
+        const postDate = postContent.createdAt;
+        const formattedDate = postDate.toLocaleString("ja-JP", {
+            year: "numeric",
+            month: "2-digit",
+            day: "2-digit",
+            hour: "2-digit",
+            minute: "2-digit",
+        });
+
+        return (
+            <time>{formattedDate}</time>
+        );
+    }
+
+    const getReaction = () => {
+        return (
+            <div>
+                {reactionTypes.map((reactionType, index) => {
+                    const reactionName = reactionNames[index];
+
+                    return (
+                        <div>
+                            <fetcher.Form method="post" action="app/like">
+                                <input type="hidden" name="reaction" value={reactionType} />
+                                <button type="submit">{reactionName}</button>
+                            </fetcher.Form>
+                        </div>
+                    );
+                })}
+            </div>
+        );
+    }
+
+    const snsUser = useSnsUser();
+
+    return (
+        <div>
+            <div>
+                <p>{snsUser.name}</p>
+                <span>{postContent.releaseVersion}</span>
+                <span>{postContent.tag}</span>
+                {getPostTime()}
+            </div>
+            <div>
+                <p>{postContent.content}</p>
+            </div>
+            <div>
+                <div>
+                    <Link to="app/reply">リプライ</Link>
+                    <button>リポスト</button>
+                </div>
+                {getReaction()}
+            </div>
+        </div>
+    );
+}

--- a/tests/dependency-injector/app-load-context.ts
+++ b/tests/dependency-injector/app-load-context.ts
@@ -5,6 +5,7 @@ import UserRegistrationAction from "../../app/actions/authentication/user-regist
 import MockUserRegistrar from "../libraries/authentication/mock-user-registrar";
 import MockUserAuthenticator from "../libraries/authentication/mock-user-authenticator";
 import MockAuthenticatedUserProvider from "../libraries/user/mock-authenticated-user-provider";
+import LatestPostsLoader from "../../app/loaders/post/latest-posts-loader";
 
 // ユーザー登録を行うためのクラスを生成する。
 const userRegistrar = new MockUserRegistrar();
@@ -18,9 +19,13 @@ const userAuthenticationAction = new UserAuthenticationAction(userAuthenticator)
 const authenticatedUserProvider = new MockAuthenticatedUserProvider();
 const ff14SnsUserLoader = new FF14SnsUserLoader(authenticatedUserProvider);
 
+// 最新の投稿を取得するためのクラスを生成する。
+const latestPostsLoader = new LatestPostsLoader();
+
 const appLoadContext: AppLoadContext = {
     userRegistrationAction,
     userAuthenticationAction,
     ff14SnsUserLoader,
+    latestPostsLoader,
 };
 export default appLoadContext;

--- a/tests/loaders/post/latest-posts-loader.spec.ts
+++ b/tests/loaders/post/latest-posts-loader.spec.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect, beforeEach } from "@jest/globals";
+import LatestPostsLoader from "../../../app/loaders/post/latest-posts-loader";
+
+/**
+ * 最新の投稿を取得するローダー。
+ */
+let latestPostsLoader: LatestPostsLoader;
+
+beforeEach(() => {
+    latestPostsLoader = new LatestPostsLoader();
+});
+
+describe("getLatestPosts", () => {
+    test("getLatestPosts should return 10 PostContent objects with correct values.", async () => {
+        // 最新の投稿を取得する。
+        const id = "0";
+        const response = await latestPostsLoader.getLatestPosts(id);
+
+        // 結果を検証する。
+        expect(response.length).toBe(10);
+        response.forEach((postContent, i) => {
+            const incrementedId = (i + Number(id) + 1).toString();
+            const content = `
+                これはポスト${incrementedId}のテストです。\n
+                これはポスト${incrementedId}のテストです。\n
+                これはポスト${incrementedId}のテストです。\n
+                これはポスト${incrementedId}のテストです。\n
+                これはポスト${incrementedId}のテストです。\n
+            `
+            expect(postContent).toEqual({
+                id: incrementedId,
+                releaseVersion: "5.5",
+                tag: "考察",
+                createdAt: expect.any(Date),
+                content: content,
+            });
+        });
+    });
+});

--- a/tests/routes/app._index/route.spec.ts
+++ b/tests/routes/app._index/route.spec.ts
@@ -1,0 +1,64 @@
+import { describe, test, expect, beforeEach } from "@jest/globals";
+import { AppLoadContext } from "@netlify/remix-runtime";
+import appLoadContext from "../../dependency-injector/app-load-context";
+import { loader } from "../../../app/routes/app._index/route";
+import { newlyPostedPostCookie } from "../../../app/cookies.server";
+
+/**
+ * クッキーなしのモックリクエスト。
+ */
+let requestWithoutCookie: Request;
+
+/**
+ * クッキー付きのモックリクエスト。
+ */
+let requestWithCookie: Request;
+
+/**
+ * モックコンテキスト。
+ */
+let context: AppLoadContext;
+
+beforeEach(async () => {
+    requestWithoutCookie = new Request("https://example.com");
+    requestWithCookie = new Request("https://example.com", {
+        headers: {
+            Cookie: await newlyPostedPostCookie.serialize({
+                isPosted: true,
+            }),
+        },
+    });
+    context = appLoadContext;
+});
+
+describe("loader", () => {
+    test('loader should return 10 PostContent objects.', async () => {
+        // ローダーを実行し、結果を取得する。
+        const response = await loader({
+            request: requestWithoutCookie,
+            params: {},
+            context,
+        });
+
+        // 検証に必要な情報を取得する。
+        const resultPostContents = await response.json();
+
+        // 結果を検証する。
+        expect(resultPostContents.length).toBe(10);
+    });
+
+    test('loader should return 10 PostContent objects with cookie.', async () => {
+        // ローダーを実行し、結果を取得する。
+        const response = await loader({
+            request: requestWithCookie,
+            params: {},
+            context,
+        });
+
+        // 検証に必要な情報を取得する。
+        const resultPostContents = await response.json();
+
+        // 結果を検証する。
+        expect(resultPostContents.length).toBe(10);
+    });
+});

--- a/tests/routes/app._index/route.spec.ts
+++ b/tests/routes/app._index/route.spec.ts
@@ -32,7 +32,7 @@ beforeEach(async () => {
 });
 
 describe("loader", () => {
-    test('loader should return 10 PostContent objects.', async () => {
+    test("loader should return 10 PostContent objects.", async () => {
         // ローダーを実行し、結果を取得する。
         const response = await loader({
             request: requestWithoutCookie,
@@ -47,7 +47,7 @@ describe("loader", () => {
         expect(resultPostContents.length).toBe(10);
     });
 
-    test('loader should return 10 PostContent objects with cookie.', async () => {
+    test("loader should return 10 PostContent objects with cookie.", async () => {
         // ローダーを実行し、結果を取得する。
         const response = await loader({
             request: requestWithCookie,

--- a/tests/routes/app.latest-posts.id/route.spec.ts
+++ b/tests/routes/app.latest-posts.id/route.spec.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, beforeEach } from "@jest/globals";
+import { AppLoadContext } from "@netlify/remix-runtime";
+import appLoadContext from "../../dependency-injector/app-load-context";
+import { loader } from "../../../app/routes/app.latest-posts.$id/route";
+
+/**
+ * モックリクエスト。
+ */
+let request: Request;
+
+/**
+ * モックコンテキスト。
+ */
+let context: AppLoadContext;
+
+beforeEach(async () => {
+    request = new Request("https://example.com");
+    context = appLoadContext;
+});
+
+describe("loader", () => {
+    test("loader should return 10 PostContent objects with ids ranging from 11 to 20.", async () => {
+        // ローダーを実行し、結果を取得する。
+        const response = await loader({
+            request: request,
+            params: {
+                id: "10",
+            },
+            context,
+        });
+
+        // 検証に必要な情報を取得する。
+        const resultPostContents = await response.json();
+
+        // 結果を検証する。
+        expect(resultPostContents.length).toBe(10);
+        expect(resultPostContents[0].id).toBe("11");
+        expect(resultPostContents[1].id).toBe("12");
+        expect(resultPostContents[2].id).toBe("13");
+        expect(resultPostContents[3].id).toBe("14");
+        expect(resultPostContents[4].id).toBe("15");
+        expect(resultPostContents[5].id).toBe("16");
+        expect(resultPostContents[6].id).toBe("17");
+        expect(resultPostContents[7].id).toBe("18");
+        expect(resultPostContents[8].id).toBe("19");
+        expect(resultPostContents[9].id).toBe("20");
+    });
+
+    test("loader should return an empty object when no parameter is provided.", async () => {
+        // ローダーを実行し、結果を取得する。
+        const response = await loader({
+            request: request,
+            params: {},
+            context,
+        });
+
+        // 検証に必要な情報を取得する。
+        const resultPostContents = await response.json();
+
+        // 結果を検証する。
+        expect(resultPostContents.length).toBe(0);
+    });
+
+    test("loader should return an empty object when the input parameter is an empty string.", async () => {
+        // ローダーを実行し、結果を取得する。
+        const response = await loader({
+            request: request,
+            params: {
+                id: "",
+            },
+            context,
+        });
+
+        // 検証に必要な情報を取得する。
+        const resultPostContents = await response.json();
+
+        // 結果を検証する。
+        expect(resultPostContents.length).toBe(0);
+    });
+});

--- a/types/app-load-context.d.ts
+++ b/types/app-load-context.d.ts
@@ -1,3 +1,4 @@
+import LatestPostsLoader from "../app/loaders/post/latest-posts-loader";
 import UserAuthenticationAction from "../app/actions/authentication/user-authentication-action";
 import UserRegistrationAction from "../app/actions/authentication/user-registration-action";
 import FF14SnsUserLoader from "../app/loaders/user/ff14-sns-user-loader";
@@ -7,5 +8,6 @@ declare module '@netlify/remix-runtime' {
         userRegistrationAction: UserRegistrationAction;
         userAuthenticationAction: UserAuthenticationAction;
         ff14SnsUserLoader: FF14SnsUserLoader;
+        latestPostsLoader: LatestPostsLoader;
     }
 }


### PR DESCRIPTION
## 概要
トップページのモックを追加した。
#25 の一部対応。

## 実装内容
* トップページのモック
* トップページで投稿を無限スクロールする機能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- SNSユーザーコンテキストの作成機能を追加しました。
	- 新しい投稿をクッキーに保存する機能を導入しました。
	- 最新の投稿を取得するための「最新投稿ローダー」を実装しました。
	- 投稿の内容を表す「投稿コンテンツ」インターフェースを導入しました。
	- 最新の投稿を表示するコンポーネントを追加しました。
	- 無限スクロール機能を備えたコンポーネントを導入しました。

- **バグ修正**
	- 特になし

- **ドキュメント**
	- 特になし

- **リファクタ**
	- アプリケーションのルーティングを更新し、最新の投稿を無限にスクロールして表示する機能を改善しました。

- **スタイル**
	- 特になし

- **テスト**
	- 最新の投稿を取得する機能のテストケースを追加しました。

- **雑務**
	- 特になし

- **リバート**
	- 特になし

<!-- end of auto-generated comment: release notes by coderabbit.ai -->