### PR TITLE
投稿時間を日本時間で表示できるようにした

### DIFF
--- a/app/routes/components/infinite-scroll.tsx
+++ b/app/routes/components/infinite-scroll.tsx
@@ -77,7 +77,10 @@ export default function InfiniteScroll<T extends Entity[]>({
         }
 
         // フェッチしたデータを追加する。
-        const data = fetcher.data as T;
+        const data = (fetcher.data as T).map((item) => ({
+            ...item,
+            createdAt: new Date(item.createdAt)
+        }));
         if (data.length > 0) {
             setContents((prevContents: T) => [...prevContents, ...data] as T);
             setShouldFetch(true);

--- a/app/routes/components/post-display.tsx
+++ b/app/routes/components/post-display.tsx
@@ -19,6 +19,7 @@ export default function PostDisplay({
     const getPostTime = () => {
         const postDate = postContent.createdAt;
         const formattedDate = postDate.toLocaleString("ja-JP", {
+            timeZone: "Asia/Tokyo",
             year: "numeric",
             month: "2-digit",
             day: "2-digit",


### PR DESCRIPTION
## 概要
投稿時間を日本時間で表示できるようにした。
#59 の対応。

## 修正方法
データベースから取得したタイムスタンプをフロントエンド側のDateクラスで日本時間に変更した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- 無限スクロールコンポーネントのロジックを変更し、フェッチしたデータの`createdAt`フィールドを`Date`オブジェクトに変換して既存のコンテンツに追加するようにしました。
	- `PostDisplay`コンポーネントの`getPostTime`関数で`toLocaleString`メソッドに`timeZone`パラメータを追加し、「Asia/Tokyo」をタイムゾーンとして指定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->