### PR TITLE
ユーザー登録、削除に失敗した時、falseを返すようにした

### DIFF
--- a/app/repositories/post/postgres-post-content-repository.ts
+++ b/app/repositories/post/postgres-post-content-repository.ts
@@ -36,9 +36,7 @@ export default class PostgresPostContentRepository implements IPostContentReposi
             const postInsertResult = await client.query(postInsertQuery, postInsertValues);
 
             // 結果がない場合、エラーを投げる。
-            if (postInsertResult.rowCount === 0) {
-                throw new Error("投稿に失敗しました。");
-            }
+            if (postInsertResult.rowCount === 0) throw new Error("投稿に失敗しました。");
 
             // 投稿IDを取得する。
             const postId = postInsertResult.rows[0].id;
@@ -58,9 +56,7 @@ export default class PostgresPostContentRepository implements IPostContentReposi
             const releaseInformationAssociationResult = await client.query(releaseInformationAssociationInsertQuery, releaseInformationAssociationInsertValues);
 
             // 結果がない場合、エラーを投げる。
-            if (releaseInformationAssociationResult.rowCount === 0) {
-                throw new Error("投稿に失敗しました。");
-            }
+            if (releaseInformationAssociationResult.rowCount === 0) throw new Error("投稿に失敗しました。");
 
             // コミットする。
             await client.query("COMMIT");

--- a/app/repositories/user/postgres-user-repository.ts
+++ b/app/repositories/user/postgres-user-repository.ts
@@ -19,6 +19,8 @@ export default class PostgresUserRepository implements IUserRepository {
         const client = await this.postgresClientProvider.get();
         try {
             await client.query("BEGIN");
+
+            // ユーザーを作成する。
             const query = `
                 INSERT INTO users (
                     profile_id,
@@ -32,7 +34,12 @@ export default class PostgresUserRepository implements IUserRepository {
                 );
             `;
             const values = [profileId, authenticationProviderId, userName];
-            await client.query(query, values);
+            const result = await client.query(query, values);
+
+            // 結果がない場合、falseを返す。
+            if (result.rowCount === 0) return false;
+
+            // コミットする。
             await client.query("COMMIT");
             return true;
         } catch (error) {
@@ -51,11 +58,18 @@ export default class PostgresUserRepository implements IUserRepository {
         const client = await this.postgresClientProvider.get();
         try {
             await client.query("BEGIN");
+
+            // ユーザーを削除する。
             const query = `
                 DELETE FROM users WHERE id = $1;
             `;
             const values = [id];
-            await client.query(query, values);
+            const result = await client.query(query, values);
+
+            // 結果がない場合、falseを返す。
+            if (result.rowCount === 0) return false;
+
+            // コミットする。
             await client.query("COMMIT");
             return true;
         } catch (error) {

--- a/app/routes/auth.register-user/route.tsx
+++ b/app/routes/auth.register-user/route.tsx
@@ -31,7 +31,12 @@ export const action = async ({
         const authenticationProviderId = await authenticatedUserLoader.getAuthenticationProviderId(cookie.idToken);
 
         // ユーザーを登録する。
-        await context.snsUserRegistrationAction.register(authenticationProviderId, userName);
+        const isRegistered = await context.snsUserRegistrationAction.register(authenticationProviderId, userName);
+
+        // ユーザー登録に失敗した場合、エラーを返す。
+        if (!isRegistered) return json({ error: "ユーザー登録に失敗しました。" });
+
+        // ユーザー登録に成功した場合、トップページにリダイレクトする。
         return redirect("/app");
     } catch (error) {
         console.error(error);

--- a/tests/repositories/user/mock-user-repository.ts
+++ b/tests/repositories/user/mock-user-repository.ts
@@ -6,6 +6,7 @@ import IUserRepository from "../../../app/repositories/user/i-user-repository";
  */
 export default class MockUserRepository implements IUserRepository {
     public async create(profileId: string, authenticationProviderId: string, userName: string): Promise<boolean> {
+        if (userName === "errorUserName@World") return false;
         return true;
     }
 


### PR DESCRIPTION
## 概要
ユーザー登録、削除に失敗した時、falseを返すようにした。
#60 の対応。

## 補足
以前まではユーザー登録、削除は成功、もしくはエラーがスローされるの2パターンしかないと考えていた。
そのため、失敗時にfalseを返す処理を省略していた。
だが、予期しない可能性を考慮しSQLで影響した行がない場合、falseを返すようにした。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ユーザー登録が成功した際にトップページへのリダイレクトを追加。
	- ユーザー登録に失敗した場合のエラーメッセージを返す機能を追加。

- **バグ修正**
	- ユーザー登録のテストで、登録不可能なシナリオとエラーメッセージを検証するテストを追加。

- **ドキュメント**
	- ユーザー作成と削除の操作に関する日本語コメントを追加。

- **リファクタ**
	- 投稿とユーザーリポジトリのエラーハンドリングロジックを簡素化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->