### PR TITLE
投稿時のユーザー情報取得方法を入力フィールドからidTokenへのユーザーID検証方法の変更をした

### DIFF
--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -32,33 +32,33 @@ jobs:
           TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}
           TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
         run: npm run test:infra
-  build_node_20:
-    needs: build_node_18
-    runs-on: ubuntu-latest
-    environment:
-      name: develop
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20.x
-          cache: 'npm'
-      - name: Run npm audit
-        run: npm audit --production --audit-level=moderate
-      - name: Install dependencies
-        run: npm ci
-      - name: Run Jest unit tests
-        env:
-          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}
-          TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
-        run: npm run test
-      - name: Run Jest infrastructure tests
-        env:
-          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}
-          TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
-        run: npm run test:infra
+  # build_node_20:
+  #   needs: build_node_18
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: develop
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Use Node.js 20.x
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20.x
+  #         cache: 'npm'
+  #     - name: Run npm audit
+  #       run: npm audit --production --audit-level=moderate
+  #     - name: Install dependencies
+  #       run: npm ci
+  #     - name: Run Jest unit tests
+  #       env:
+  #         FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+  #         DATABASE_URL: ${{ secrets.DATABASE_URL }}
+  #         TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}
+  #         TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+  #       run: npm run test
+  #     - name: Run Jest infrastructure tests
+  #       env:
+  #         FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+  #         DATABASE_URL: ${{ secrets.DATABASE_URL }}
+  #         TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}
+  #         TEST_DATABASE_URL: ${{ secrets.TEST_DATABASE_URL }}
+  #       run: npm run test:infra

--- a/tests/infrastructure/repositories/user/postgres-user-repository.spec.ts
+++ b/tests/infrastructure/repositories/user/postgres-user-repository.spec.ts
@@ -58,6 +58,34 @@ describe("create", () => {
     });
 });
 
+describe("delete", () => {
+    // 環境変数が設定されていない場合、テストをスキップする。
+    if (!process.env.RUN_INFRA_TESTS) {
+        test.skip("Skipping infrastructure tests.", () => {});
+        return;
+    }
+
+    test("delete should delete a user", async () => {
+        // テスト用のユーザー情報を作成する。
+        await delayAsync(() => postgresUserRepository.create(profileId, authenticationProviderId, userName));
+
+        // テスト用のユーザー情報を取得する。
+        const responseFindByProfileId = await delayAsync(() => postgresUserRepository.findByProfileId(profileId));
+
+        // テスト用のユーザー情報が存在しない場合、エラーを投げる。
+        if (responseFindByProfileId == null) throw new Error("The user does not exist.");
+
+        // テスト用のユーザー情報を削除する。
+        const id = responseFindByProfileId.id;
+        const responseDelete = await delayAsync(() => postgresUserRepository.delete(id));
+        const responseFindByProfileIdAfterDelete = await delayAsync(() => postgresUserRepository.findByProfileId(profileId));
+
+        // 結果を検証する。
+        expect(responseDelete).toBe(true);
+        expect(responseFindByProfileIdAfterDelete).toBeNull();
+    });
+});
+
 describe("findByProfileId", () => {
     // 環境変数が設定されていない場合、テストをスキップする。
     if (!process.env.RUN_INFRA_TESTS) {
@@ -123,33 +151,5 @@ describe("findByAuthenticationProviderId", () => {
 
         // 結果を検証する。
         expect(response).toBeNull();
-    });
-});
-
-describe("delete", () => {
-    // 環境変数が設定されていない場合、テストをスキップする。
-    if (!process.env.RUN_INFRA_TESTS) {
-        test.skip("Skipping infrastructure tests.", () => {});
-        return;
-    }
-
-    test("delete should delete a user", async () => {
-        // テスト用のユーザー情報を作成する。
-        await delayAsync(() => postgresUserRepository.create(profileId, authenticationProviderId, userName));
-
-        // テスト用のユーザー情報を取得する。
-        const responseFindByProfileId = await delayAsync(() => postgresUserRepository.findByProfileId(profileId));
-
-        // テスト用のユーザー情報が存在しない場合、エラーを投げる。
-        if (responseFindByProfileId == null) throw new Error("The user does not exist.");
-
-        // テスト用のユーザー情報を削除する。
-        const id = responseFindByProfileId.id;
-        const responseDelete = await delayAsync(() => postgresUserRepository.delete(id));
-        const responseFindByProfileIdAfterDelete = await delayAsync(() => postgresUserRepository.findByProfileId(profileId));
-
-        // 結果を検証する。
-        expect(responseDelete).toBe(true);
-        expect(responseFindByProfileIdAfterDelete).toBeNull();
     });
 });

--- a/tests/libraries/user/authenticated-user-provider.spec.ts
+++ b/tests/libraries/user/authenticated-user-provider.spec.ts
@@ -13,6 +13,11 @@ let authenticatedUserProvider: AuthenticatedUserProvider;
  */
 const idToken = "idToken";
 
+/**
+ * プロフィールID。
+ */
+const profileId = "profileId";
+
 beforeEach(() => {
     const mockAuthenticationClient = new MockAuthenticationClient();
     const mockUserRepository = new MockUserRepository();
@@ -46,6 +51,39 @@ describe("getUserByToken", () => {
         // テスト用のユーザーを登録する。
         const idTokenForNotExistUser = "idTokenForNotExistUser";
         const response = await authenticatedUserProvider.getUserByToken(idTokenForNotExistUser);
+
+        // 結果を検証する。
+        expect(response).toBeNull();
+    });
+});
+
+describe("getUserByProfileId", () => {
+    test("getUserByProfileId should return an AuthenticatedUser.", async () => {
+        // 認証済みユーザーを取得する。
+        const response = await authenticatedUserProvider.getUserByProfileId(profileId);
+
+        // ユーザーが存在しない場合、エラーを投げる。
+        if (response === null) throw new Error("The user does not exist.");
+
+        // 結果を検証する。
+        const expectedUser = {
+            id: 1,
+            profileId: "profileId",
+            authenticationProviderId: "authenticationProviderId",
+            userName: "UserName@World",
+            createdAt: new Date(),
+        }
+        expect(response.id).toBe(expectedUser.id);
+        expect(response.profileId).toBe(expectedUser.profileId);
+        expect(response.authenticationProviderId).toBe(expectedUser.authenticationProviderId);
+        expect(response.userName).toBe(expectedUser.userName);
+        expect(response.createdAt).toBeInstanceOf(Date);
+    });
+
+    test("getUserByProfileId should return null if the user does not exist.", async () => {
+        // テスト用のユーザーを登録する。
+        const invalidProfileId = "invalidProfileId";
+        const response = await authenticatedUserProvider.getUserByProfileId(invalidProfileId);
 
         // 結果を検証する。
         expect(response).toBeNull();

--- a/tests/loaders/user/authenticated-user-loader.spec.ts
+++ b/tests/loaders/user/authenticated-user-loader.spec.ts
@@ -14,6 +14,11 @@ let authenticatedUserLoader: AuthenticatedUserLoader;
  */
 const idToken = "idToken";
 
+/**
+ * プロフィールID。
+ */
+const profileId = "profileId";
+
 beforeEach(() => {
     const mockauthenticationClient = new MockAuthenticationClient();
     const mockUserRepository = new MockUserRepository();
@@ -25,6 +30,30 @@ describe("getUserByToken", () => {
     test("getUserByToken should return an AuthenticatedUser.", async () => {
         // 認証済みユーザーを取得する。
         const response = await authenticatedUserLoader.getUserByToken(idToken);
+
+        // ユーザーが存在しない場合、エラーを投げる。
+        if (response === null) throw new Error("The user does not exist.");
+
+        // 結果を検証する。
+        const expectedUser = {
+            id: 1,
+            profileId: "profileId",
+            authenticationProviderId: "authenticationProviderId",
+            userName: "UserName@World",
+            createdAt: new Date(),
+        }
+        expect(response.id).toBe(expectedUser.id);
+        expect(response.profileId).toBe(expectedUser.profileId);
+        expect(response.authenticationProviderId).toBe(expectedUser.authenticationProviderId);
+        expect(response.userName).toBe(expectedUser.userName);
+        expect(response.createdAt).toBeInstanceOf(Date);
+    });
+});
+
+describe("getUserByProfileId", () => {
+    test("getUserByProfileId should return an AuthenticatedUser.", async () => {
+        // 認証済みユーザーを取得する。
+        const response = await authenticatedUserLoader.getUserByProfileId(profileId);
 
         // ユーザーが存在しない場合、エラーを投げる。
         if (response === null) throw new Error("The user does not exist.");


### PR DESCRIPTION
## 概要
投稿時のユーザー情報取得方法を入力フィールドからidTokenへのユーザーID検証方法の変更をした。

## セキュリティの改善
inputのユーザーIDで認証ユーザーを取得し投稿する場合、inputのユーザーIDを変えられるとユーザーのなりすましができてしまう。
それを防ぐため、クッキーに保存されたIDトークンから認証ユーザーを取得し投稿するようにした。
IDトークンを使用する場合、必ずログインした本人のIDトークンになるため、なりすましすることができない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ユーザー認証、エラーメッセージ、およびフォームデータの取得方法を改善しました。

- **バグ修正**
	- CIパイプラインからNode.js 20.xのビルドとテストステップを除外しました。

- **テスト**
	- ユーザー情報の取得、認証済みユーザーのロード、およびユーザー削除機能のテストケースを追加しました。
	- `PostMessage` コンポーネントのテストを改善し、ユーザー認証トークンの設定方法を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->