### PR TITLE
ユーザー認証でクッキーセッションストレージを使うようにした

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-SESSION_SERCRET_KEY=your_secret_key
+SESSION_SECRET_KEY=your_secret_key
 FIREBASE_API_KEY=your_api_key
 DATABASE_URL=your_connection_string
 RUN_INFRA_TESTS=

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+SESSION_SERCRET_KEY=your_secret_key
 FIREBASE_API_KEY=your_api_key
 DATABASE_URL=your_connection_string
 RUN_INFRA_TESTS=
+TEST_FIREBASE_API_KEY=your_api_key
+TEST_DATABASE_URL=your_connection_string

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -20,7 +20,7 @@ jobs:
         run: npm ci
       - name: Run Jest unit tests
         env:
-          SESSION_SERCRET_KEY: ${{ secrets.SESSION_SERCRET_KEY }}
+          SESSION_SECRET_KEY: ${{ secrets.SESSION_SECRET_KEY }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}
@@ -28,7 +28,7 @@ jobs:
         run: npm run test
       - name: Run Jest infrastructure tests
         env:
-          SESSION_SERCRET_KEY: ${{ secrets.SESSION_SERCRET_KEY }}
+          SESSION_SECRET_KEY: ${{ secrets.SESSION_SECRET_KEY }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}
@@ -52,7 +52,7 @@ jobs:
   #       run: npm ci
   #     - name: Run Jest unit tests
   #       env:
-  #         SESSION_SERCRET_KEY: ${{ secrets.SESSION_SERCRET_KEY }}
+  #         SESSION_SECRET_KEY: ${{ secrets.SESSION_SECRET_KEY }}
   #         FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
   #         DATABASE_URL: ${{ secrets.DATABASE_URL }}
   #         TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}
@@ -60,7 +60,7 @@ jobs:
   #       run: npm run test
   #     - name: Run Jest infrastructure tests
   #       env:
-  #         SESSION_SERCRET_KEY: ${{ secrets.SESSION_SERCRET_KEY }}
+  #         SESSION_SECRET_KEY: ${{ secrets.SESSION_SECRET_KEY }}
   #         FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
   #         DATABASE_URL: ${{ secrets.DATABASE_URL }}
   #         TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -20,6 +20,7 @@ jobs:
         run: npm ci
       - name: Run Jest unit tests
         env:
+          SESSION_SERCRET_KEY: ${{ secrets.SESSION_SERCRET_KEY }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}
@@ -51,6 +52,7 @@ jobs:
   #       run: npm ci
   #     - name: Run Jest unit tests
   #       env:
+  #         SESSION_SERCRET_KEY: ${{ secrets.SESSION_SERCRET_KEY }}
   #         FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
   #         DATABASE_URL: ${{ secrets.DATABASE_URL }}
   #         TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -27,6 +27,7 @@ jobs:
         run: npm run test
       - name: Run Jest infrastructure tests
         env:
+          SESSION_SERCRET_KEY: ${{ secrets.SESSION_SERCRET_KEY }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}
@@ -57,6 +58,7 @@ jobs:
   #       run: npm run test
   #     - name: Run Jest infrastructure tests
   #       env:
+  #         SESSION_SERCRET_KEY: ${{ secrets.SESSION_SERCRET_KEY }}
   #         FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
   #         DATABASE_URL: ${{ secrets.DATABASE_URL }}
   #         TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}

--- a/.github/workflows/nodejs_unit_tests.yml
+++ b/.github/workflows/nodejs_unit_tests.yml
@@ -21,6 +21,7 @@ jobs:
         run: npm ci
       - name: Run Unit Tests
         env:
+          SESSION_SERCRET_KEY: ${{ secrets.SESSION_SERCRET_KEY }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}

--- a/.github/workflows/nodejs_unit_tests.yml
+++ b/.github/workflows/nodejs_unit_tests.yml
@@ -21,7 +21,7 @@ jobs:
         run: npm ci
       - name: Run Unit Tests
         env:
-          SESSION_SERCRET_KEY: ${{ secrets.SESSION_SERCRET_KEY }}
+          SESSION_SECRET_KEY: ${{ secrets.SESSION_SECRET_KEY }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           TEST_FIREBASE_API_KEY: ${{ secrets.TEST_FIREBASE_API_KEY }}

--- a/app/cookies.server.ts
+++ b/app/cookies.server.ts
@@ -4,6 +4,7 @@ import { createCookie } from "@remix-run/node";
  * ユーザー認証用のCookie。
  */
 export const userAuthenticationCookie = createCookie("user-authentication", {
+    path: "/",
     secure: true,
     httpOnly: true,
     sameSite: "lax",
@@ -14,6 +15,7 @@ export const userAuthenticationCookie = createCookie("user-authentication", {
  * 新規投稿した投稿のIDを保持するCookie。
  */
 export const newlyPostedPostCookie = createCookie("newly-posted-post", {
+    path: "/",
     secure: true,
     httpOnly: true,
     sameSite: "lax",

--- a/app/cookies.server.ts
+++ b/app/cookies.server.ts
@@ -1,17 +1,6 @@
 import { createCookie } from "@remix-run/node";
 
 /**
- * ユーザー認証用のCookie。
- */
-export const userAuthenticationCookie = createCookie("user-authentication", {
-    path: "/",
-    secure: true,
-    httpOnly: true,
-    sameSite: "lax",
-    maxAge: 2_592_000,
-});
-
-/**
  * 新規投稿した投稿のIDを保持するCookie。
  */
 export const newlyPostedPostCookie = createCookie("newly-posted-post", {

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,7 +1,7 @@
 import { LoaderFunctionArgs, MetaFunction, json, redirect } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
 import { useState } from "react";
-import { userAuthenticationCookie } from "../cookies.server";
+import { getSession } from "../sessions";
 
 export const meta: MetaFunction = () => {
   return [
@@ -14,8 +14,8 @@ export async function loader({
   request,
 }: LoaderFunctionArgs) {
   const cookieHeader = request.headers.get("Cookie");
-  const cookie = (await userAuthenticationCookie.parse(cookieHeader)) || {};
-  if (Object.keys(cookie).length <= 0) return redirect("/auth/login");
+  const session = await getSession(cookieHeader);
+  if (!session.has("userId")) return redirect("/auth/login");
   return redirect("/app");
 }
 

--- a/app/routes/app.post-message/route.tsx
+++ b/app/routes/app.post-message/route.tsx
@@ -1,6 +1,7 @@
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from "@remix-run/node";
 import { Form, useLoaderData } from "@remix-run/react";
-import { userAuthenticationCookie, newlyPostedPostCookie } from "../../cookies.server";
+import { getSession } from "../../sessions";
+import { newlyPostedPostCookie } from "../../cookies.server";
 import { appLoadContext as context } from "../../dependency-injector/get-load-context";
 
 /**
@@ -39,10 +40,10 @@ export const action = async ({
     try {
         // 認証済みユーザーを取得する。
         const cookieHeader = request.headers.get("Cookie");
-        const cookieUserAuthentication = (await userAuthenticationCookie.parse(cookieHeader)) || {};
-        const idToken = cookieUserAuthentication.idToken;
+        const session = await getSession(cookieHeader);
+        const profileId = session.get("userId") as string;
         const authenticatedUserLoader = context.authenticatedUserLoader;
-        const authenticatedUser = await authenticatedUserLoader.getUserByToken(idToken);
+        const authenticatedUser = await authenticatedUserLoader.getUserByProfileId(profileId);
 
         // 認証済みユーザーが取得できない場合、エラーを返す。
         if (!authenticatedUser) return json({ error: "メッセージの投稿に失敗しました。" });

--- a/app/routes/app/route.tsx
+++ b/app/routes/app/route.tsx
@@ -1,7 +1,7 @@
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from "@remix-run/node";
 import { Outlet, useLoaderData } from "@remix-run/react";
 import SnsUserProvider from "../../contexts/user/sns-user-provider";
-import { userAuthenticationCookie } from "../../cookies.server";
+import { commitSession, destroySession, getSession } from "../../sessions";
 import Header from "./components/header";
 import Footer from "./components/footer";
 import SnsUser from "../../models/user/sns-user";
@@ -29,22 +29,39 @@ export const loader = async ({
     request,
 }: LoaderFunctionArgs) => {
     try {
-        // ログインしていない場合、ログインページにリダイレクトする。
+        // ユーザー登録が完了していない場合、ユーザー登録ページにリダイレクトする。
         const cookieHeader = request.headers.get("Cookie");
-        const cookie = (await userAuthenticationCookie.parse(cookieHeader)) || {};
-        if (Object.keys(cookie).length <= 0) return redirect("/auth/login", {
-            headers: {
-                "Set-Cookie": await userAuthenticationCookie.serialize({}),
-            },
-        });
+        const session = await getSession(cookieHeader);
+        if (session.has("idToken") && !session.has("userId")) {
+            return redirect("/auth/register-user", {
+                headers: {
+                    "Set-Cookie": await commitSession(session),
+                },
+            });
+        }
+
+        // ログインしていない場合、ログインページにリダイレクトする。
+        if (!session.has("userId")) {
+            return redirect("/auth/login", {
+                headers: {
+                    "Set-Cookie": await destroySession(session),
+                },
+            });
+        }
 
         // 認証済みユーザーを取得する。
+        const profileId = session.get("userId") as string;
         const authenticatedUserLoader = context.authenticatedUserLoader;
-        const authenticatedUser = await authenticatedUserLoader.getUserByToken(cookie.idToken);
+        const authenticatedUser = await authenticatedUserLoader.getUserByProfileId(profileId);
 
         // 認証済みユーザーが存在しない場合、ユーザー登録ページにリダイレクトする。
         if (!authenticatedUser) {
-            return redirect("/auth/register-user");
+            session.unset("userId");
+            return redirect("/auth/register-user", {
+                headers: {
+                    "Set-Cookie": await commitSession(session),
+                },
+            });
         }
 
         // SNSのユーザーを返す。
@@ -52,12 +69,20 @@ export const loader = async ({
             userId: authenticatedUser.profileId,
             userName: authenticatedUser.userName,
         };
-        return json(snsUser);
+        return json(snsUser, {
+            headers: {
+                "Set-Cookie": await commitSession(session),
+            },
+        });
     } catch (error) {
         console.error(error);
+
+        // エラーが発生した場合、ログインページにリダイレクトする。
+        const cookieHeader = request.headers.get("Cookie");
+        const session = await getSession(cookieHeader);
         throw redirect("/auth/login", {
             headers: {
-                "Set-Cookie": await userAuthenticationCookie.serialize({}),
+                "Set-Cookie": await destroySession(session),
             },
         });
     }
@@ -73,30 +98,28 @@ export const action = async ({
     request,
 }: ActionFunctionArgs) => {
     try {
-        // ログインしていない場合、ログインページにリダイレクトする。
-        const cookieHeader = request.headers.get("Cookie");
-        const cookie = (await userAuthenticationCookie.parse(cookieHeader)) || {};
-        if (Object.keys(cookie).length <= 0) return redirect("/auth/login", {
-            headers: {
-                "Set-Cookie": await userAuthenticationCookie.serialize({}),
-            },
-        });
-
         // ログアウトする。
+        const cookieHeader = request.headers.get("Cookie");
+        const session = await getSession(cookieHeader);
+        const idToken = session.get("idToken") as string;
         const userAuthenticationAction = context.userAuthenticationAction;
-        await userAuthenticationAction.logout(cookie.idToken);
+        await userAuthenticationAction.logout(idToken);
 
         // IDトークンとリフレッシュトークンをCookieから削除する。
         return redirect("/auth/login", {
             headers: {
-                "Set-Cookie": await userAuthenticationCookie.serialize({}),
+                "Set-Cookie": await destroySession(session),
             },
         });
     } catch (error) {
         console.error(error);
+
+        // エラーが発生した場合、ログインページにリダイレクトする。
+        const cookieHeader = request.headers.get("Cookie");
+        const session = await getSession(cookieHeader);
         throw redirect("/auth/login", {
             headers: {
-                "Set-Cookie": await userAuthenticationCookie.serialize({}),
+                "Set-Cookie": await destroySession(session),
             },
         });
     }

--- a/app/routes/auth.login/route.tsx
+++ b/app/routes/auth.login/route.tsx
@@ -1,8 +1,12 @@
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from "@remix-run/node";
 import { Form } from "@remix-run/react";
-import { userAuthenticationCookie } from "../../cookies.server";
+import { commitSession, getSession } from "../../sessions";
 import { appLoadContext as context } from "../../dependency-injector/get-load-context";
 
+/**
+ * ログインページのメタ情報を設定する。
+ * @returns ログインページのメタ情報。
+ */
 export const meta: MetaFunction = () => {
     return [
         { title: "FF14 SNS ログイン" },
@@ -10,16 +14,35 @@ export const meta: MetaFunction = () => {
     ];
 }
 
+/**
+ * ログインページのローダー。
+ * @param request リクエスト。
+ * @param context コンテキスト。
+ * @returns ログインしている場合、トップページにリダイレクトする。
+ */
 export const loader = async ({
     request,
 }: LoaderFunctionArgs) => {
     // ログインしている場合、トップページにリダイレクトする。
     const cookieHeader = request.headers.get("Cookie");
-    const cookie = (await userAuthenticationCookie.parse(cookieHeader)) || {};
-    if (Object.keys(cookie).length > 0) return redirect("/app");
+    const session = await getSession(cookieHeader);
+    if (session.has("userId")) {
+        return redirect("/app", {
+            headers: {
+                "Set-Cookie": await commitSession(session),
+            },
+        });
+    }
     return null;
 }
 
+/**
+ * ログインページのアクション。
+ * @param request リクエスト。
+ * @param context コンテキスト。
+ * @returns トップページにリダイレクトする。
+ * 認証済みユーザーが存在しない場合、ユーザー登録ページにリダイレクトする。
+ */
 export const action = async ({
     request,
 }: ActionFunctionArgs) => {
@@ -33,13 +56,34 @@ export const action = async ({
         const userAuthenticationAction = context.userAuthenticationAction;
         const response = await userAuthenticationAction.login(mailAddress, password);
 
-        // IDトークンとリフレッシュトークンをCookieに保存する。
-        const cookie: any = {};
-        cookie.idToken = response.idToken;
-        cookie.refreshToken = response.refreshToken;
+        // IDトークンとリフレッシュトークンをセッションに保存する。
+        const idToken = response.idToken;
+        const refreshToken = response.refreshToken;
+        const cookieHeader = request.headers.get("Cookie");
+        const session = await getSession(cookieHeader);
+        session.set("idToken", idToken);
+        session.set("refreshToken", refreshToken);
+
+        // 認証済みユーザーを取得する。
+        const authenticatedUserLoader = context.authenticatedUserLoader;
+        const authenticatedUser = await authenticatedUserLoader.getUserByToken(idToken);
+
+        // 認証済みユーザーが存在しない場合、ユーザー登録ページにリダイレクトする。
+        if (!authenticatedUser) {
+            return redirect("/auth/register-user", {
+                headers: {
+                    "Set-Cookie": await commitSession(session),
+                },
+            });
+        }
+
+        // ユーザーIDをセッションに保存する。
+        session.set("userId", authenticatedUser.profileId);
+
+        // トップページにリダイレクトする。
         return redirect("/app", {
             headers: {
-                "Set-Cookie": await userAuthenticationCookie.serialize(cookie),
+                "Set-Cookie": await commitSession(session),
             },
         });
     } catch (error) {
@@ -48,6 +92,10 @@ export const action = async ({
     }
 }
 
+/**
+ * ログインページ。
+ * @returns ログインページ。
+ */
 export default function Login() {
     return (
         <Form method="post">

--- a/app/routes/auth.register-user/route.tsx
+++ b/app/routes/auth.register-user/route.tsx
@@ -1,7 +1,43 @@
-import { ActionFunctionArgs, json, redirect } from "@remix-run/node";
+import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from "@remix-run/node";
 import { Form } from "@remix-run/react";
-import { userAuthenticationCookie } from "../../cookies.server";
+import { commitSession, destroySession, getSession } from "../../sessions";
 import { appLoadContext as context } from "../../dependency-injector/get-load-context";
+
+/**
+ * ログインページのメタ情報を設定する。
+ * @returns ログインページのメタ情報。
+ */
+export const meta: MetaFunction = () => {
+    return [
+        { title: "FF14 SNS ユーザー登録" },
+        { name: "description", content: "FF14SNSのユーザー登録ページです。" },
+    ];
+}
+
+export const loader = async ({
+    request,
+}: LoaderFunctionArgs) => {
+    // ログインしている場合、トップページにリダイレクトする。
+    const cookieHeader = request.headers.get("Cookie");
+    const session = await getSession(cookieHeader);
+    if (session.has("userId")) {
+        return redirect("/app", {
+            headers: {
+                "Set-Cookie": await commitSession(session),
+            },
+        });
+    }
+
+    // ログインしていない場合、ログインページにリダイレクトする。
+    if (!session.has("idToken")) {
+        return redirect("/auth/login", {
+            headers: {
+                "Set-Cookie": await destroySession(session),
+            },
+        });
+    }
+    return null;
+}
 
 /**
  * SNSのユーザー登録を行うアクション。
@@ -13,22 +49,16 @@ export const action = async ({
     request,
 }: ActionFunctionArgs) => {
     try {
-        // ログインしていない場合、ログインページにリダイレクトする。
-        const cookieHeader = request.headers.get("Cookie");
-        const cookie = (await userAuthenticationCookie.parse(cookieHeader)) || {};
-        if (Object.keys(cookie).length <= 0) return redirect("/auth/login", {
-            headers: {
-                "Set-Cookie": await userAuthenticationCookie.serialize({}),
-            },
-        });
-
         // フォームデータを取得する。
         const formData = await request.formData();
         const userName = formData.get("userName") as string;
 
         // 認証プロバイダーIDを取得する。
+        const cookieHeader = request.headers.get("Cookie");
+        const session = await getSession(cookieHeader);
+        const idToken = session.get("idToken") as string;
         const authenticatedUserLoader = context.authenticatedUserLoader;
-        const authenticationProviderId = await authenticatedUserLoader.getAuthenticationProviderId(cookie.idToken);
+        const authenticationProviderId = await authenticatedUserLoader.getAuthenticationProviderId(idToken);
 
         // ユーザーを登録する。
         const isRegistered = await context.snsUserRegistrationAction.register(authenticationProviderId, userName);
@@ -36,8 +66,26 @@ export const action = async ({
         // ユーザー登録に失敗した場合、エラーを返す。
         if (!isRegistered) return json({ error: "ユーザー登録に失敗しました。" });
 
+        // 認証済みユーザーを取得する。
+        const authenticatedUser = await authenticatedUserLoader.getUserByToken(idToken);
+
+        // 認証済みユーザーが存在しない場合、エラーを返す。
+        if (!authenticatedUser) {
+            return redirect("/auth/login", {
+                headers: {
+                    "Set-Cookie": await destroySession(session),
+                },
+            });
+        }
+
         // ユーザー登録に成功した場合、トップページにリダイレクトする。
-        return redirect("/app");
+        const userId = authenticatedUser.profileId;
+        session.set("userId", userId);
+        return redirect("/app", {
+            headers: {
+                "Set-Cookie": await commitSession(session),
+            },
+        });
     } catch (error) {
         console.error(error);
         return json({ error: "ユーザー登録に失敗しました。" });
@@ -51,8 +99,10 @@ export const action = async ({
 export default function RegisterUser() {
     return (
         <Form method="post">
-            <label htmlFor="userName">FF14のユーザー名(user_name@world)</label>
-            <input type="text" name="userName" />
+            { /** userNameにメールアドレスが入らないようにしている。 */ }
+            <input type="text" style={{ display: "none" }} />
+            <label htmlFor="userName">FF14のユーザー名(UserName@world)</label>
+            <input type="text" name="userName" autoComplete="off" />
             <button type="submit">登録</button>
         </Form>
     );

--- a/app/routes/auth.signup/route.tsx
+++ b/app/routes/auth.signup/route.tsx
@@ -1,25 +1,47 @@
 import { ActionFunctionArgs, LoaderFunctionArgs, MetaFunction, json, redirect } from "@remix-run/node";
 import { Form } from "@remix-run/react";
-import { userAuthenticationCookie } from "../../cookies.server";
+import { commitSession, getSession } from "../../sessions";
 import { appLoadContext as context } from "../../dependency-injector/get-load-context";
 
+/**
+ * サインアップページのメタ情報を設定する。
+ * @returns サインインページのメタ情報。
+ */
 export const meta: MetaFunction = () => {
     return [
-        { title: "FF14 SNS サインイン" },
-        { name: "description", content: "FF14SNSのサインインページです。" },
+        { title: "FF14 SNS サインアップ" },
+        { name: "description", content: "FF14SNSのサインアップページです。" },
     ];
 }
 
+/**
+ * サインアップページのローダー。
+ * @param request リクエスト。
+ * @param context コンテキスト。
+ * @returns ログインしている場合、トップページにリダイレクトする。
+ */
 export const loader = async ({
     request,
 }: LoaderFunctionArgs) => {
     // ログインしている場合、トップページにリダイレクトする。
     const cookieHeader = request.headers.get("Cookie");
-    const cookie = (await userAuthenticationCookie.parse(cookieHeader)) || {};
-    if (Object.keys(cookie).length > 0) return redirect("/app");
+    const session = await getSession(cookieHeader);
+    if (session.has("userId")) {
+        return redirect("/app", {
+            headers: {
+                "Set-Cookie": await commitSession(session),
+            },
+        });
+    }
     return null;
 }
 
+/**
+ * サインアップページのアクション。
+ * @param request リクエスト。
+ * @param context コンテキスト。
+ * @returns ユーザー登録ページにリダイレクトする。
+ */
 export const action = async ({
     request,
 }: ActionFunctionArgs) => {
@@ -37,21 +59,30 @@ export const action = async ({
         const userRegistrationAction = context.userRegistrationAction;
         const response = await userRegistrationAction.register(mailAddress, password);
 
-        // IDトークンとリフレッシュトークンをCookieに保存する。
-        const cookie: any = {};
-        cookie.idToken = response.idToken;
-        cookie.refreshToken = response.refreshToken;
-        return redirect("/app", {
+        // IDトークンとリフレッシュトークンをセッションに保存する。
+        const idToken = response.idToken;
+        const refreshToken = response.refreshToken;
+        const cookieHeader = request.headers.get("Cookie");
+        const session = await getSession(cookieHeader);
+        session.set("idToken", idToken);
+        session.set("refreshToken", refreshToken);
+
+        // ユーザー登録ページにリダイレクトする。
+        return redirect("/auth/register-user", {
             headers: {
-                "Set-Cookie": await userAuthenticationCookie.serialize(cookie),
+                "Set-Cookie": await commitSession(session),
             },
         });
     } catch (error) {
         console.error(error);
-        return json({ error: "ログインに失敗しました。" });
+        return json({ error: "サインアップに失敗しました。" });
     }
 }
 
+/**
+ * サインアップページ。
+ * @returns サインアップページ。
+ */
 export default function Signup() {
     return (
         <Form method="post">
@@ -67,7 +98,7 @@ export default function Signup() {
                 <span>パスワード再確認</span>
                 <input type="password" name="confirmPassword" />
             </label>
-            <button type="submit">サインイン</button>
+            <button type="submit">サインアップ</button>
         </Form>
     );
 }

--- a/app/routes/auth/route.tsx
+++ b/app/routes/auth/route.tsx
@@ -3,6 +3,10 @@ import { Outlet } from "@remix-run/react";
 import Header from "./components/header";
 import Footer from "./components/footer";
 
+/**
+ * 認証ページのメタ情報を設定する。
+ * @returns 認証ページのメタ情報。
+ */
 export const meta: MetaFunction = () => {
     return [
         { title: "FF14 SNS" },
@@ -10,6 +14,10 @@ export const meta: MetaFunction = () => {
     ];
 }
 
+/**
+ * 認証ページ。
+ * @returns 認証ページ。
+ */
 export default function Auth() {
     return (
         <main>

--- a/app/sessions.ts
+++ b/app/sessions.ts
@@ -1,0 +1,46 @@
+import { createCookieSessionStorage } from "@remix-run/node";
+
+if (!process.env.SESSION_SERCRET_KEY) {
+    throw new Error("SESSION_SERCRET_KEYが設定されていません。");
+}
+
+/**
+ * セッションに保存するデータ。
+ */
+type SessionData = {
+    /**
+     * IDトークン。
+     */
+    idToken: string;
+
+    /**
+     * リフレッシュトークン。
+     */
+    refreshToken: string;
+
+    /**
+     * ユーザーID。
+     */
+    userId: string;
+}
+
+const {
+    getSession,
+    commitSession,
+    destroySession,
+} = createCookieSessionStorage<SessionData>({
+    cookie: {
+        name: "__session",
+        path: "/",
+        secrets: [process.env.SESSION_SERCRET_KEY],
+        secure: true,
+        httpOnly: true,
+        sameSite: "lax",
+        maxAge: 2_592_000,
+    },
+});
+export {
+    getSession,
+    commitSession,
+    destroySession,
+};

--- a/app/sessions.ts
+++ b/app/sessions.ts
@@ -1,7 +1,7 @@
 import { createCookieSessionStorage } from "@remix-run/node";
 
-if (!process.env.SESSION_SERCRET_KEY) {
-    throw new Error("SESSION_SERCRET_KEYが設定されていません。");
+if (!process.env.SESSION_SECRET_KEY) {
+    throw new Error("SESSION_SECRET_KEYが設定されていません。");
 }
 
 /**
@@ -32,7 +32,7 @@ const {
     cookie: {
         name: "__session",
         path: "/",
-        secrets: [process.env.SESSION_SERCRET_KEY],
+        secrets: [process.env.SESSION_SECRET_KEY],
         secure: true,
         httpOnly: true,
         sameSite: "lax",

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -5,7 +5,7 @@ declare global {
     PORT: string;
     RUN_UNIT_TESTS: string;
     RUN_INFRA_TESTS: string;
-    SESSION_SERCRET_KEY: string | undefined;
+    SESSION_SECRET_KEY: string | undefined;
     FIREBASE_API_KEY: string | undefined;
     DATABASE_URL: string | undefined;
     TEST_FIREBASE_API_KEY: string | undefined;

--- a/globals.d.ts
+++ b/globals.d.ts
@@ -5,6 +5,7 @@ declare global {
     PORT: string;
     RUN_UNIT_TESTS: string;
     RUN_INFRA_TESTS: string;
+    SESSION_SERCRET_KEY: string | undefined;
     FIREBASE_API_KEY: string | undefined;
     DATABASE_URL: string | undefined;
     TEST_FIREBASE_API_KEY: string | undefined;

--- a/tests/infrastructure/loaders/post/latest-posts-loader.spec.ts
+++ b/tests/infrastructure/loaders/post/latest-posts-loader.spec.ts
@@ -6,6 +6,7 @@ import PostgresUserRepository from "../../../../app/repositories/user/postgres-u
 import PostgresPostContentRepository from "../../../../app/repositories/post/postgres-post-content-repository";
 import PostInteractor from "../../../../app/libraries/post/post-interactor";
 import PostsFetcher from "../../../../app/libraries/post/posts-fetcher";
+import LatestPostsLoader from "../../../../app/loaders/post/latest-posts-loader";
 
 /**
  * Postgresのユーザーリポジトリ。
@@ -28,6 +29,11 @@ let postInteractor: PostInteractor;
 let postsFetcher: PostsFetcher;
 
 /**
+ * 最新の投稿を取得するローダー。
+ */
+let latestPostsLoader: LatestPostsLoader;
+
+/**
  * プロフィールID。
  */
 const profileId = "username_world";
@@ -42,6 +48,7 @@ beforeEach(async () => {
     postgresPostContentRepository = new PostgresPostContentRepository(postgresClientProvider);
     postInteractor = new PostInteractor(postgresPostContentRepository);
     postsFetcher = new PostsFetcher(postgresPostContentRepository);
+    latestPostsLoader = new LatestPostsLoader(postsFetcher);
     await deleteRecordForTest();
 });
 
@@ -49,8 +56,8 @@ afterEach(async () => {
     await deleteRecordForTest();
 });
 
-describe("fetchLatestPosts" , () => {
-    test("fetchLatestPosts should return latest posts.", async () => {
+describe("getLatestPosts" , () => {
+    test("getLatestPosts should return latest posts.", async () => {
         // テスト用のユーザー情報を登録する。
         const authenticationProviderId = "authenticationProviderId";
         await postgresUserRepository.create(profileId, authenticationProviderId, userName);
@@ -61,13 +68,13 @@ describe("fetchLatestPosts" , () => {
         // ユーザーが存在しない場合、エラーを投げる。
         if (responseAuthenticatedUser === null) throw new Error("The user does not exist.");
 
-        // テスト用の投稿を登録する。
+        // 投稿を作成する。
         const posterId = responseAuthenticatedUser.id;
         const postContent = "postContent";
         const postId = await postInteractor.post(posterId, 1, postContent);
 
-        // 投稿を取得する。
-        const posts = await postsFetcher.fetchLatestPosts(1);
+        // 最新の投稿を取得する。
+        const posts = await latestPostsLoader.getLatestPosts();
 
         // 結果を検証する。
         expect(posts.length).toBe(1);

--- a/tests/infrastructure/routes/app._index/route.spec.ts
+++ b/tests/infrastructure/routes/app._index/route.spec.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect, beforeEach, afterEach } from "@jest/globals";
+import delayAsync from "../../../test-utilityies/delay-async";
+import deleteRecordForTest from "../../../infrastructure/common/delete-record-for-test";
+import { AppLoadContext } from "@remix-run/node";
+import { appLoadContext, postgresClientProvider } from "../../../../app/dependency-injector/get-load-context";
+import PostgresUserRepository from "../../../../app/repositories/user/postgres-user-repository";
+import PostgresPostContentRepository from "../../../../app/repositories/post/postgres-post-content-repository";
+import PostInteractor from "../../../../app/libraries/post/post-interactor";
+import PostsFetcher from "../../../../app/libraries/post/posts-fetcher";
+import { commitSession, getSession } from "../../../../app/sessions";
+import { newlyPostedPostCookie } from "../../../../app/cookies.server";
+import { loader } from "../../../../app/routes/app._index/route";
+
+/**
+ * Postgresのユーザーリポジトリ。
+ */
+let postgresUserRepository: PostgresUserRepository;
+
+/**
+ * Postgresの投稿内容リポジトリ。
+ */
+let postgresPostContentRepository: PostgresPostContentRepository;
+
+/**
+ * 投稿に関する処理を行うクラス。
+ */
+let postInteractor: PostInteractor;
+
+/**
+ * 投稿を取得するクラス。
+ */
+let postsFetcher: PostsFetcher;
+
+/**
+ * プロフィールID。
+ */
+const profileId = "username_world";
+
+/**
+ * ユーザー名。
+ */
+const userName = "UserName@World";
+
+/**
+ * コンテキスト。
+ */
+let context: AppLoadContext;
+
+beforeEach(async () => {
+    postgresUserRepository = new PostgresUserRepository(postgresClientProvider);
+    postgresPostContentRepository = new PostgresPostContentRepository(postgresClientProvider);
+    postInteractor = new PostInteractor(postgresPostContentRepository);
+    postsFetcher = new PostsFetcher(postgresPostContentRepository);
+    context = appLoadContext;
+    await deleteRecordForTest();
+});
+
+afterEach(async () => {
+    await deleteRecordForTest();
+});
+
+describe("loader" , () => {
+    test("loader should return latest posts.", async () => {
+        // テスト用のユーザー情報を登録する。
+        const authenticationProviderId = "authenticationProviderId";
+        await postgresUserRepository.create(profileId, authenticationProviderId, userName);
+
+        // 認証済みユーザーを取得する。
+        const responseAuthenticatedUser = await delayAsync(() => postgresUserRepository.findByAuthenticationProviderId(authenticationProviderId));
+
+        // ユーザーが存在しない場合、エラーを投げる。
+        if (responseAuthenticatedUser === null) throw new Error("The user does not exist.");
+
+        // 認証済みユーザーの投稿を登録する。
+        const posterId = responseAuthenticatedUser.id;
+        const postContent = "postContent";
+        const postId = await postInteractor.post(posterId, 1, postContent);
+
+        // ローダーを実行し、結果を取得する。
+        const session = await getSession();
+        session.set("idToken", "idToken");
+        session.set("refreshToken", "refreshToken");
+        session.set("userId", profileId);
+        const requestWithCookie = new Request("https://example.com", {
+            headers: {
+                Cookie: await commitSession(session),
+            },
+        });
+        const response = await loader({
+            request: requestWithCookie,
+            params: {},
+            context,
+        });
+
+        // 検証に必要な情報を取得する。
+        const posts = await response.json();
+
+        // 結果を検証する。
+        expect(posts.length).toBe(1);
+        expect(posts[0].id).toBe(postId);
+        expect(posts[0].posterId).toBe(profileId);
+        expect(posts[0].releaseInformationId).toBe(1);
+        expect(posts[0].content).toBe(postContent);
+        expect(new Date(posts[0].createdAt)).toBeInstanceOf(Date);
+    });
+
+    test("loader should return before posts if user has cookie.", async () => {
+        // テスト用のユーザー情報を登録する。
+        const authenticationProviderId = "authenticationProviderId";
+        await postgresUserRepository.create(profileId, authenticationProviderId, userName);
+
+        // 認証済みユーザーを取得する。
+        const responseAuthenticatedUser = await delayAsync(() => postgresUserRepository.findByAuthenticationProviderId(authenticationProviderId));
+
+        // ユーザーが存在しない場合、エラーを投げる。
+        if (responseAuthenticatedUser === null) throw new Error("The user does not exist.");
+
+        // 認証済みユーザーの投稿を登録する。
+        const posterId = responseAuthenticatedUser.id;
+        const postContent = "postContent";
+        const postId = await postInteractor.post(posterId, 1, postContent);
+
+        // ローダーを実行し、結果を取得する。
+        const session = await getSession();
+        session.set("idToken", "idToken");
+        session.set("refreshToken", "refreshToken");
+        session.set("userId", profileId);
+        const sessionCookie = await commitSession(session);
+        const cookie = {
+            postId: postId,
+        };
+        const postCookie = await newlyPostedPostCookie.serialize(cookie);
+        const requestWithCookie = new Request("https://example.com", {
+            headers: {
+                Cookie: `${sessionCookie}; ${postCookie}`,
+            },
+        });
+        const response = await loader({
+            request: requestWithCookie,
+            params: {},
+            context,
+        });
+
+        // 検証に必要な情報を取得する。
+        const posts = await response.json();
+
+        // 結果を検証する。
+        expect(posts.length).toBe(1);
+        expect(posts[0].id).toBe(postId);
+        expect(posts[0].posterId).toBe(profileId);
+        expect(posts[0].releaseInformationId).toBe(1);
+        expect(posts[0].content).toBe(postContent);
+        expect(new Date(posts[0].createdAt)).toBeInstanceOf(Date);
+    });
+});

--- a/tests/infrastructure/routes/app.latest-posts.id/route.spec.ts
+++ b/tests/infrastructure/routes/app.latest-posts.id/route.spec.ts
@@ -1,11 +1,14 @@
 import { describe, test, expect, beforeEach, afterEach } from "@jest/globals";
 import delayAsync from "../../../test-utilityies/delay-async";
 import deleteRecordForTest from "../../../infrastructure/common/delete-record-for-test";
-import { postgresClientProvider } from "../../../../app/dependency-injector/get-load-context";
+import { AppLoadContext } from "@remix-run/node";
+import { appLoadContext, postgresClientProvider } from "../../../../app/dependency-injector/get-load-context";
 import PostgresUserRepository from "../../../../app/repositories/user/postgres-user-repository";
 import PostgresPostContentRepository from "../../../../app/repositories/post/postgres-post-content-repository";
 import PostInteractor from "../../../../app/libraries/post/post-interactor";
 import PostsFetcher from "../../../../app/libraries/post/posts-fetcher";
+import { commitSession, getSession } from "../../../../app/sessions";
+import { loader } from "../../../../app/routes/app.latest-posts.$id/route";
 
 /**
  * Postgresのユーザーリポジトリ。
@@ -37,11 +40,17 @@ const profileId = "username_world";
  */
 const userName = "UserName@World";
 
+/**
+ * コンテキスト。
+ */
+let context: AppLoadContext;
+
 beforeEach(async () => {
     postgresUserRepository = new PostgresUserRepository(postgresClientProvider);
     postgresPostContentRepository = new PostgresPostContentRepository(postgresClientProvider);
     postInteractor = new PostInteractor(postgresPostContentRepository);
     postsFetcher = new PostsFetcher(postgresPostContentRepository);
+    context = appLoadContext;
     await deleteRecordForTest();
 });
 
@@ -49,8 +58,8 @@ afterEach(async () => {
     await deleteRecordForTest();
 });
 
-describe("fetchLatestPosts" , () => {
-    test("fetchLatestPosts should return latest posts.", async () => {
+describe("loader", () => {
+    test("loader should return posts before the specified id.", async () => {
         // テスト用のユーザー情報を登録する。
         const authenticationProviderId = "authenticationProviderId";
         await postgresUserRepository.create(profileId, authenticationProviderId, userName);
@@ -61,13 +70,31 @@ describe("fetchLatestPosts" , () => {
         // ユーザーが存在しない場合、エラーを投げる。
         if (responseAuthenticatedUser === null) throw new Error("The user does not exist.");
 
-        // テスト用の投稿を登録する。
+        // 認証済みユーザーの投稿を登録する。
         const posterId = responseAuthenticatedUser.id;
         const postContent = "postContent";
         const postId = await postInteractor.post(posterId, 1, postContent);
 
-        // 投稿を取得する。
-        const posts = await postsFetcher.fetchLatestPosts(1);
+        // ローダーを実行し、結果を取得する。
+        const session = await getSession();
+        session.set("idToken", "idToken");
+        session.set("refreshToken", "refreshToken");
+        session.set("userId", profileId);
+        const requestWithCookie = new Request("https://example.com", {
+            headers: {
+                Cookie: await commitSession(session),
+            },
+        });
+        const response = await loader({
+            request: requestWithCookie,
+            params: {
+                id: postId.toString(),
+            },
+            context,
+        });
+
+        // 検証に必要な情報を取得する。
+        const posts = await response.json();
 
         // 結果を検証する。
         expect(posts.length).toBe(1);
@@ -75,6 +102,6 @@ describe("fetchLatestPosts" , () => {
         expect(posts[0].posterId).toBe(profileId);
         expect(posts[0].releaseInformationId).toBe(1);
         expect(posts[0].content).toBe(postContent);
-        expect(posts[0].createdAt).toBeInstanceOf(Date);
+        expect(new Date(posts[0].createdAt)).toBeInstanceOf(Date);
     });
 });

--- a/tests/infrastructure/routes/app/route.spec.ts
+++ b/tests/infrastructure/routes/app/route.spec.ts
@@ -181,7 +181,7 @@ describe("action", () => {
     //         // 検証に必要な情報を取得する。
     //         const status = error.status;
     //         const redirect = error.headers.get("Location");
-    //         const cookie = await userAuthenticationCookie.parse(error.headers.get("Set-Cookie"));
+    //         const cookie = await getSession(error.headers.get("Set-Cookie"));
 
     //         // 結果を検証する。
     //         expect(status).toBe(302);

--- a/tests/infrastructure/routes/auth.login/route.spec.ts
+++ b/tests/infrastructure/routes/auth.login/route.spec.ts
@@ -1,15 +1,22 @@
-import { describe, test, expect, beforeEach } from "@jest/globals";
+import { describe, test, expect, beforeEach, afterEach } from "@jest/globals";
 import delayAsync from "../../../test-utilityies/delay-async";
+import deleteRecordForTest from "../../../infrastructure/common/delete-record-for-test";
 import FirebaseClient from "../../../../app/libraries/authentication/firebase-client";
+import PostgresUserRepository from "../../../../app/repositories/user/postgres-user-repository";
 import { AppLoadContext } from "@remix-run/node";
 import { action } from "../../../../app/routes/auth.login/route";
-import { appLoadContext } from "../../../../app/dependency-injector/get-load-context";
-import { userAuthenticationCookie } from "../../../../app/cookies.server";
+import { appLoadContext, postgresClientProvider } from "../../../../app/dependency-injector/get-load-context";
+import { getSession } from "../../../../app/sessions";
 
 /**
  * Firebaseのクライアント。
  */
 let firebaseClient: FirebaseClient;
+
+/**
+ * Postgresのユーザーリポジトリ。
+ */
+let postgresUserRepository: PostgresUserRepository;
 
 /**
  * テスト用のメールアドレス。
@@ -22,67 +29,29 @@ const mailAddress = "test@example.com";
 const password = "testPassword123";
 
 /**
- * モックコンテキスト。
+ * プロフィールID。
+ */
+const profileId = "username_world";
+
+/**
+ * ユーザー名。
+ */
+const userName = "UserName@World";
+
+/**
+ * コンテキスト。
  */
 let context: AppLoadContext;
 
-/**
- * メールアドレスとパスワードが正しいモックリクエスト。
- */
-let requestWithMailAddressAndPassword: Request;
-
-/**
- * メールアドレスが不正なモックリクエスト。
- */
-let requestWithInvalidEmail: Request;
-
-/**
- * パスワードが不正なモックリクエスト。
- */
-let requestWithInvalidPassword: Request;
-
 beforeEach(async () => {
-    // Firebaseのクライアントを生成する。
     firebaseClient = new FirebaseClient();
-
-    // テスト用のユーザーが存在する場合、削除する。
-    try {
-        // テスト用のユーザーをログインする。
-        const responseSignIn = await delayAsync(() => firebaseClient.signInWithEmailPassword(mailAddress, password));
-
-        // テスト用のユーザーを削除する。
-        const idToken = responseSignIn.idToken;
-        await delayAsync(() => firebaseClient.deleteUser(idToken));
-        console.info("テスト用のユーザーを削除しました。");
-    } catch (error) {
-        console.info("テスト用のユーザーは存在しませんでした。");
-    }
-
-    // コンテキストを設定する。
+    postgresUserRepository = new PostgresUserRepository(postgresClientProvider);
     context = appLoadContext;
+    await deleteRecordForTest();
+});
 
-    // モックリクエストを作成する。
-    requestWithMailAddressAndPassword = new Request("https://example.com", {
-        method: "POST",
-        body: new URLSearchParams({
-            mailAddress: mailAddress,
-            password: password,
-        }),
-    });
-    requestWithInvalidEmail = new Request("https://example.com", {
-        method: "POST",
-        body: new URLSearchParams({
-            mailAddress: "invalid-email",
-            password: password,
-        }),
-    });
-    requestWithInvalidPassword = new Request("https://example.com", {
-        method: "POST",
-        body: new URLSearchParams({
-            mailAddress: mailAddress,
-            password: "invalid-password",
-        }),
-    });
+afterEach(async () => {
+    await deleteRecordForTest();
 });
 
 describe("action", () => {
@@ -94,9 +63,20 @@ describe("action", () => {
 
     test("action should redirect app page.", async () => {
         // テスト用のユーザーを作成する。
-        await delayAsync(() => firebaseClient.signUp(mailAddress, password));
+        const responseSignUp = await delayAsync(() => firebaseClient.signUp(mailAddress, password));
+
+        // テスト用のユーザー情報を登録する。
+        const authenticationProviderId = responseSignUp.localId;
+        await delayAsync(() => postgresUserRepository.create(profileId, authenticationProviderId, userName));
 
         // アクションを実行し、結果を取得する。
+        const requestWithMailAddressAndPassword = new Request("https://example.com", {
+            method: "POST",
+            body: new URLSearchParams({
+                mailAddress: mailAddress,
+                password: password,
+            }),
+        });
         const response = await action({
             request: requestWithMailAddressAndPassword,
             params: {},
@@ -106,50 +86,13 @@ describe("action", () => {
         // 検証に必要な情報を取得する。
         const status = response.status;
         const location = response.headers.get("Location");
-        const cookie = await userAuthenticationCookie.parse(response.headers.get("Set-Cookie"));
+        const session = await getSession(response.headers.get("Set-Cookie"));
 
         // 結果を検証する。
         expect(status).toBe(302);
         expect(location).toBe("/app");
-        expect(cookie).toBeDefined();
-    });
-
-    test("action should return error information for invalid email.", async () => {
-        // 無効なメールアドレスでアクションを実行し、結果を取得する。
-        const response = await action({
-            request: requestWithInvalidEmail,
-            params: {},
-            context,
-        });
-
-        // 検証に必要な情報を取得する。
-        const errorInformation = await response.json();
-
-        // 結果を検証する。
-        const expectedErrorInformation = {
-            error: "ログインに失敗しました。",
-        };
-        expect(errorInformation).toEqual(expectedErrorInformation);
-    });
-
-    test("action should return error information for invalid password.", async () => {
-        // テスト用のユーザーを作成する。
-        await delayAsync(() => firebaseClient.signUp(mailAddress, password));
-
-        // 無効なパスワードでアクションを実行し、結果を取得する。
-        const response = await action({
-            request: requestWithInvalidPassword,
-            params: {},
-            context,
-        });
-
-        // 検証に必要な情報を取得する。
-        const errorInformation = await response.json();
-
-        // 結果を検証する。
-        const expectedErrorInformation = {
-            error: "ログインに失敗しました。",
-        };
-        expect(errorInformation).toEqual(expectedErrorInformation);
+        expect(session.has("idToken")).toBe(true);
+        expect(session.has("refreshToken")).toBe(true);
+        expect(session.has("userId")).toBe(true);
     });
 });

--- a/tests/infrastructure/routes/auth.register-user/route.spec.ts
+++ b/tests/infrastructure/routes/auth.register-user/route.spec.ts
@@ -1,21 +1,16 @@
-import { describe, test, expect, beforeEach } from "@jest/globals";
+import { describe, test, expect, beforeEach, afterEach } from "@jest/globals";
 import delayAsync from "../../../test-utilityies/delay-async";
+import deleteRecordForTest from "../../../infrastructure/common/delete-record-for-test";
 import FirebaseClient from "../../../../app/libraries/authentication/firebase-client";
-import PostgresUserRepository from "../../../../app/repositories/user/postgres-user-repository";
 import { AppLoadContext } from "@remix-run/node";
 import { action } from "../../../../app/routes/auth.register-user/route";
-import { appLoadContext, postgresClientProvider } from "../../../../app/dependency-injector/get-load-context";
-import { userAuthenticationCookie } from "../../../../app/cookies.server";
+import { appLoadContext } from "../../../../app/dependency-injector/get-load-context";
+import { commitSession, getSession } from "../../../../app/sessions";
 
 /**
  * Firebaseのクライアント。
  */
 let firebaseClient: FirebaseClient;
-
-/**
- * Postgresのユーザーリポジトリ。
- */
-let postgresUserRepository: PostgresUserRepository;
 
 /**
  * テスト用のメールアドレス。
@@ -26,11 +21,6 @@ const mailAddress = "test@example.com";
  * テスト用のパスワード。
  */
 const password = "testPassword123";
-
-/**
- * プロフィールID。
- */
-const profileId = "username_world";
 
 /**
  * ユーザー名。
@@ -44,38 +34,12 @@ let context: AppLoadContext;
 
 beforeEach(async () => {
     firebaseClient = new FirebaseClient();
-    postgresUserRepository = new PostgresUserRepository(postgresClientProvider);
-
-    // テスト用のユーザーが存在する場合、削除する。
-    try {
-        // テスト用のユーザーをログインする。
-        const responseSignIn = await delayAsync(() => firebaseClient.signInWithEmailPassword(mailAddress, password));
-
-        // テスト用のユーザーを削除する。
-        const idToken = responseSignIn.idToken;
-        await delayAsync(() => firebaseClient.deleteUser(idToken));
-        console.info("テスト用のユーザーを削除しました。");
-    } catch (error) {
-        console.info("テスト用のユーザーは存在しませんでした。");
-    }
-
-    // テスト用のユーザー情報が存在する場合、削除する。
-    try {
-        // テスト用のユーザー情報を取得する。
-        const responseFindByProfileId = await delayAsync(() => postgresUserRepository.findByProfileId(profileId));
-
-        // テスト用のユーザー情報が存在しない場合、エラーを投げる。
-        if (responseFindByProfileId == null) throw new Error("The user does not exist.");
-
-        const id = responseFindByProfileId.id;
-        await delayAsync(() => postgresUserRepository.delete(id));
-        console.info("テスト用のユーザー情報を削除しました。");
-    } catch (error) {
-        console.info("テスト用のユーザー情報は存在しませんでした。");
-    }
-
-    // コンテキストを設定する。
     context = appLoadContext;
+    await deleteRecordForTest();
+});
+
+afterEach(async () => {
+    await deleteRecordForTest();
 });
 
 describe("action", () => {
@@ -90,12 +54,12 @@ describe("action", () => {
         const responseSignUp = await delayAsync(() => firebaseClient.signUp(mailAddress, password));
 
         // アクションを実行し、結果を取得する。
+        const session = await getSession();
+        session.set("idToken", responseSignUp.idToken);
+        session.set("refreshToken", responseSignUp.refreshToken);
         const requestWithCookie = new Request("https://example.com", {
             headers: {
-                Cookie: await userAuthenticationCookie.serialize({
-                    idToken: responseSignUp.idToken,
-                    refreshToken: responseSignUp.refreshToken,
-                }),
+                Cookie: await commitSession(session),
             },
             method: "POST",
             body: new URLSearchParams({
@@ -111,9 +75,13 @@ describe("action", () => {
         // 検証に必要な情報を取得する。
         const status = response.status;
         const location = response.headers.get("Location");
+        const resultSession = await getSession(response.headers.get("Set-Cookie"));
 
         // 結果を検証する。
         expect(status).toBe(302);
         expect(location).toBe("/app");
+        expect(resultSession.has("idToken")).toBe(true);
+        expect(resultSession.has("refreshToken")).toBe(true);
+        expect(resultSession.has("userId")).toBe(true);
     });
 });

--- a/tests/libraries/authentication/mock-authentication-client.ts
+++ b/tests/libraries/authentication/mock-authentication-client.ts
@@ -29,8 +29,14 @@ export default class MockAuthenticationClient implements IAuthenticationClient {
     }
 
     public async signInWithEmailPassword(mailAddress: string, password: string): Promise<SignInWithEmailPasswordResponse> {
+        // ユーザーが登録されていない場合、idTokenを無効なものにする。
+        let idToken = "idToken";
+        if (mailAddress === "notregisteredrser@example.com") {
+            idToken = "notRegisteredUserIdToken";
+        }
+
         // メールアドレスが不正な場合、エラーを投げる。
-        if (mailAddress !== "test@example.com") {
+        if (mailAddress !== "notregisteredrser@example.com" && mailAddress !== "test@example.com") {
             throw new Error("Invalid mail address.");
         }
 
@@ -42,7 +48,7 @@ export default class MockAuthenticationClient implements IAuthenticationClient {
         // メールアドレスとパスワードでサインインのレスポンスを返す。
         const response = {
             displayName: "DisplayName",
-            idToken: "idToken",
+            idToken: idToken,
             email: "test@example.com",
             refreshToken: "refreshToken",
             expiresIn: "3600",

--- a/tests/libraries/user/authenticated-user-provider.spec.ts
+++ b/tests/libraries/user/authenticated-user-provider.spec.ts
@@ -82,7 +82,7 @@ describe("getUserByProfileId", () => {
 
     test("getUserByProfileId should return null if the user does not exist.", async () => {
         // テスト用のユーザーを登録する。
-        const invalidProfileId = "invalidProfileId";
+        const invalidProfileId = "notExistProfileId";
         const response = await authenticatedUserProvider.getUserByProfileId(invalidProfileId);
 
         // 結果を検証する。

--- a/tests/repositories/user/mock-user-repository.ts
+++ b/tests/repositories/user/mock-user-repository.ts
@@ -24,6 +24,7 @@ export default class MockUserRepository implements IUserRepository {
     }
 
     public async findByProfileId(profileId: string): Promise<User | null> {
+        if (profileId === "invalidProfileId") throw new Error("Invalid profileId.");
         if (profileId !== "profileId") return null;
         const user = {
             id: 1,

--- a/tests/routes/app.post-message/route.spec.ts
+++ b/tests/routes/app.post-message/route.spec.ts
@@ -2,7 +2,8 @@ import { describe, test, expect, beforeEach } from "@jest/globals";
 import { AppLoadContext } from "@remix-run/node";
 import { appLoadContext } from "../../../app/dependency-injector/get-load-context";
 import { loader, action } from "../../../app/routes/app.post-message/route";
-import { userAuthenticationCookie, newlyPostedPostCookie } from "../../../app/cookies.server";
+import { commitSession, getSession } from "../../../app/sessions";
+import { newlyPostedPostCookie } from "../../../app/cookies.server";
 
 /**
  * モックリクエスト。
@@ -20,17 +21,24 @@ let requestWithCookieAndBody: Request;
 let requestWithInvalidCookie: Request;
 
 /**
+ * 登録されていないクッキー付きのモックリクエスト。
+ */
+let requestWithNotRegisteredUserCookie: Request;
+
+/**
  * モックコンテキスト。
  */
 let context: AppLoadContext;
 
 beforeEach(async () => {
     request = new Request("https://example.com");
+    const validSession = await getSession();
+    validSession.set("idToken", "idToken");
+    validSession.set("refreshToken", "refreshToken");
+    validSession.set("userId", "profileId");
     requestWithCookieAndBody = new Request("https://example.com", {
         headers: {
-            Cookie: await userAuthenticationCookie.serialize({
-                idToken: "idToken",
-            }),
+            Cookie: await commitSession(validSession),
         },
         method: "POST",
         body: new URLSearchParams({
@@ -38,17 +46,28 @@ beforeEach(async () => {
             content: "アクション経由の投稿テスト！",
         }),
     });
+    const invalidSession = await getSession();
+    invalidSession.set("idToken", "idToken");
+    invalidSession.set("refreshToken", "refreshToken");
+    invalidSession.set("userId", "invalidProfileId");
     requestWithInvalidCookie = new Request("https://example.com", {
         headers: {
-            Cookie: await userAuthenticationCookie.serialize({
-                idToken: "invalidIdToken",
-            }),
+            Cookie: await commitSession(invalidSession),
         },
         method: "POST",
         body: new URLSearchParams({
             releaseInformationId: "1",
             content: "アクション経由の投稿テスト！",
         }),
+    });
+    const notRegisteredUserSession = await getSession();
+    notRegisteredUserSession.set("idToken", "notRegisteredUserIdToken");
+    notRegisteredUserSession.set("refreshToken", "refreshToken");
+    notRegisteredUserSession.set("userId", "notExistProfileId");
+    requestWithNotRegisteredUserCookie = new Request("https://example.com", {
+        headers: {
+            Cookie: await commitSession(notRegisteredUserSession),
+        },
     });
     context = appLoadContext;
 });
@@ -97,7 +116,22 @@ describe("action", () => {
         });
     });
 
-    test("action should return error message when id token is invalid.", async () => {
+    test("action should return error message if user is not exist.", async () => {
+        // アクションを実行し、結果を取得する。
+        const response = await action({
+            request: requestWithNotRegisteredUserCookie,
+            params: {},
+            context,
+        });
+
+        // 検証に必要な情報を取得する。
+        const errorInformation = await response.json();
+
+        // 結果を検証する。
+        expect(errorInformation).toBeDefined();
+    });
+
+    test("action should return error message when profile id is invalid.", async () => {
         // アクションを実行し、結果を取得する。
         const response = await action({
             request: requestWithInvalidCookie,

--- a/tests/routes/app/route.spec.ts
+++ b/tests/routes/app/route.spec.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach } from "@jest/globals";
 import { AppLoadContext } from "@remix-run/node";
 import { loader, action } from "../../../app/routes/app/route";
 import { appLoadContext } from "../../../app/dependency-injector/get-load-context";
-import { userAuthenticationCookie } from "../../../app/cookies.server";
+import { commitSession, getSession } from "../../../app/sessions";
 
 /**
  * クッキーなしのモックリクエスト。
@@ -10,14 +10,19 @@ import { userAuthenticationCookie } from "../../../app/cookies.server";
 let requestWithoutCookie: Request;
 
 /**
- * クッキー付きのモックリクエスト。
- */
-let requestWithCookie: Request;
-
-/**
  * 登録されていないクッキー付きのモックリクエスト。
  */
 let requestWithNotRegisteredUserCookie: Request;
+
+/**
+ * 存在しないユーザーのクッキー付きのモックリクエスト。
+ */
+let requestWithNotExistUserCookie: Request;
+
+/**
+ * クッキー付きのモックリクエスト。
+ */
+let requestWithCookie: Request;
 
 /**
  * クッキーが不正なモックリクエスト。
@@ -30,29 +35,40 @@ let requestWithInvalidCookie: Request;
 let context: AppLoadContext;
 
 beforeEach(async () => {
-    requestWithoutCookie = new Request("https://example.com");
+    const validSession = await getSession();
+    validSession.set("idToken", "idToken");
+    validSession.set("refreshToken", "refreshToken");
+    validSession.set("userId", "profileId");
     requestWithCookie = new Request("https://example.com", {
         headers: {
-            Cookie: await userAuthenticationCookie.serialize({
-                idToken: "idToken",
-                refreshToken: "refreshToken",
-            }),
+            Cookie: await commitSession(validSession),
         },
     });
+    const notRegisteredUserSession = await getSession();
+    notRegisteredUserSession.set("idToken", "notRegisteredUserIdToken");
+    notRegisteredUserSession.set("refreshToken", "refreshToken");
     requestWithNotRegisteredUserCookie = new Request("https://example.com", {
         headers: {
-            Cookie: await userAuthenticationCookie.serialize({
-                idToken: "notRegisteredUserIdToken",
-                refreshToken: "refreshToken",
-            }),
+            Cookie: await commitSession(notRegisteredUserSession),
         },
     });
+    requestWithoutCookie = new Request("https://example.com");
+    const notExistUserSession = await getSession();
+    notExistUserSession.set("idToken", "idToken");
+    notExistUserSession.set("refreshToken", "refreshToken");
+    notExistUserSession.set("userId", "notExistProfileId");
+    requestWithNotExistUserCookie = new Request("https://example.com", {
+        headers: {
+            Cookie: await commitSession(notExistUserSession),
+        },
+    });
+    const invalidSession = await getSession();
+    invalidSession.set("userId", "invalidProfileId");
+    invalidSession.set("idToken", "idToken");
+    invalidSession.set("refreshToken", "invalidRefreshToken");
     requestWithInvalidCookie = new Request("https://example.com", {
         headers: {
-            Cookie: await userAuthenticationCookie.serialize({
-                idToken: "invalidIdToken",
-                refreshToken: "invalidRefreshToken",
-            }),
+            Cookie: await commitSession(invalidSession),
         },
     });
     context = appLoadContext;
@@ -79,25 +95,6 @@ describe("loader", () => {
         expect(resultUser.userName).toBe(expectedUser.userName);
     });
 
-    test("loader should redirect login page if user is not authenticated.", async () => {
-        // ローダーを実行し、結果を取得する。
-        const response = await loader({
-            request: requestWithoutCookie,
-            params: {},
-            context,
-        });
-
-        // 検証に必要な情報を取得する。
-        const status = response.status;
-        const redirect = response.headers.get("Location");
-        const cookie = await userAuthenticationCookie.parse(response.headers.get("Set-Cookie"));
-
-        // 結果を検証する。
-        expect(status).toBe(302);
-        expect(redirect).toBe("/auth/login");
-        expect(cookie).toStrictEqual({});
-    });
-
     test("loader should redirect to user registration page if user is not registered.", async () => {
         // ローダーを実行し、結果を取得する。
         const response = await loader({
@@ -109,10 +106,55 @@ describe("loader", () => {
         // 検証に必要な情報を取得する。
         const status = response.status;
         const redirect = response.headers.get("Location");
+        const session = await getSession(response.headers.get("Set-Cookie"));
 
         // 結果を検証する。
         expect(status).toBe(302);
         expect(redirect).toBe("/auth/register-user");
+        expect(session.has("idToken")).toBe(true);
+        expect(session.has("refreshToken")).toBe(true);
+    });
+
+    test("loader should redirect to login page if user is not authenticated.", async () => {
+        // ローダーを実行し、結果を取得する。
+        const response = await loader({
+            request: requestWithoutCookie,
+            params: {},
+            context,
+        });
+
+        // 検証に必要な情報を取得する。
+        const status = response.status;
+        const redirect = response.headers.get("Location");
+        const session = await getSession(response.headers.get("Set-Cookie"));
+
+        // 結果を検証する。
+        expect(status).toBe(302);
+        expect(redirect).toBe("/auth/login");
+        expect(session.has("idToken")).toBe(false);
+        expect(session.has("refreshToken")).toBe(false);
+        expect(session.has("userId")).toBe(false);
+    });
+
+    test("loader should redirect to login page if user is not exist.", async () => {
+        // ローダーを実行し、結果を取得する。
+        const response = await loader({
+            request: requestWithNotExistUserCookie,
+            params: {},
+            context,
+        });
+
+        // 検証に必要な情報を取得する。
+        const status = response.status;
+        const redirect = response.headers.get("Location");
+        const session = await getSession(response.headers.get("Set-Cookie"));
+
+        // 結果を検証する。
+        expect(status).toBe(302);
+        expect(redirect).toBe("/auth/register-user");
+        expect(session.has("idToken")).toBe(true);
+        expect(session.has("refreshToken")).toBe(true);
+        expect(session.has("userId")).toBe(false);
     });
 
     test("loader should redirect to login page if an error occurs.", async () => {
@@ -133,12 +175,12 @@ describe("loader", () => {
             // 検証に必要な情報を取得する。
             const status = error.status;
             const redirect = error.headers.get("Location");
-            const cookie = await userAuthenticationCookie.parse(error.headers.get("Set-Cookie"));
+            const session = await getSession(error.headers.get("Set-Cookie"));
 
             // 結果を検証する。
             expect(status).toBe(302);
             expect(redirect).toBe("/auth/login");
-            expect(cookie).toStrictEqual({});
+            expect(session.get("userId")).toBeUndefined();
         }
     });
 });
@@ -155,31 +197,14 @@ describe("action", () => {
         // 検証に必要な情報を取得する。
         const status = response.status;
         const redirect = response.headers.get("Location");
-        const cookie = await userAuthenticationCookie.parse(response.headers.get("Set-Cookie"));
+        const session = await getSession(response.headers.get("Set-Cookie"));
 
         // 結果を検証する。
         expect(status).toBe(302);
         expect(redirect).toBe("/auth/login");
-        expect(cookie).toStrictEqual({});
-    });
-
-    test("action should redirect login page if user is not authenticated.", async () => {
-        // アクションを実行し、結果を取得する。
-        const response = await action({
-            request: requestWithoutCookie,
-            params: {},
-            context,
-        });
-
-        // 検証に必要な情報を取得する。
-        const status = response.status;
-        const redirect = response.headers.get("Location");
-        const cookie = await userAuthenticationCookie.parse(response.headers.get("Set-Cookie"));
-
-        // 結果を検証する。
-        expect(status).toBe(302);
-        expect(redirect).toBe("/auth/login");
-        expect(cookie).toStrictEqual({});
+        expect(session.has("idToken")).toBe(false);
+        expect(session.has("refreshToken")).toBe(false);
+        expect(session.has("userId")).toBe(false);
     });
 
     // TODO: リフレッシュトークンを無効にしてログアウトする処理を追加した後にコメントアウトを外す。
@@ -201,7 +226,7 @@ describe("action", () => {
     //         // 検証に必要な情報を取得する。
     //         const status = error.status;
     //         const redirect = error.headers.get("Location");
-    //         const cookie = await userAuthenticationCookie.parse(error.headers.get("Set-Cookie"));
+    //         const cookie = await getSession(error.headers.get("Set-Cookie"));
 
     //         // 結果を検証する。
     //         expect(status).toBe(302);

--- a/tests/routes/auth.register-user/route.spec.ts
+++ b/tests/routes/auth.register-user/route.spec.ts
@@ -1,13 +1,18 @@
 import { describe, test, expect, beforeEach } from "@jest/globals";
-import { action } from "../../../app/routes/auth.register-user/route";
+import { action, loader } from "../../../app/routes/auth.register-user/route";
 import { AppLoadContext } from "@remix-run/node";
 import { appLoadContext } from "../../../app/dependency-injector/get-load-context";
-import { userAuthenticationCookie } from "../../../app/cookies.server";
+import { commitSession, getSession } from "../../../app/sessions";
 
 /**
  * クッキー付きのモックリクエスト。
  */
 let requestWithCookie: Request;
+
+/**
+ * 登録されているモックリクエスト。
+ */
+let requestWithLoggedInUserCookie: Request;
 
 /**
  * エラーを起こすモックリクエスト。
@@ -30,12 +35,25 @@ let requestWithoutCookie: Request;
 let context: AppLoadContext;
 
 beforeEach(async () => {
+    const validSession = await getSession();
+    validSession.set("idToken", "idToken");
+    validSession.set("refreshToken", "refreshToken");
     requestWithCookie = new Request("https://example.com", {
         headers: {
-            Cookie: await userAuthenticationCookie.serialize({
-                idToken: "idToken",
-                refreshToken: "refreshToken",
-            }),
+            Cookie: await commitSession(validSession),
+        },
+        method: "POST",
+        body: new URLSearchParams({
+            userName: "UserName@World",
+        }),
+    });
+    const loggedInUserSession = await getSession();
+    loggedInUserSession.set("idToken", "idToken");
+    loggedInUserSession.set("refreshToken", "refreshToken");
+    loggedInUserSession.set("userId", "profileId");
+    requestWithLoggedInUserCookie = new Request("https://example.com", {
+        headers: {
+            Cookie: await commitSession(loggedInUserSession),
         },
         method: "POST",
         body: new URLSearchParams({
@@ -44,10 +62,7 @@ beforeEach(async () => {
     });
     requestWithError = new Request("https://example.com", {
         headers: {
-            Cookie: await userAuthenticationCookie.serialize({
-                idToken: "idToken",
-                refreshToken: "refreshToken",
-            }),
+            Cookie: await commitSession(validSession),
         },
         method: "POST",
         body: new URLSearchParams({
@@ -56,10 +71,7 @@ beforeEach(async () => {
     });
     requestWithInvalidUserName = new Request("https://example.com", {
         headers: {
-            Cookie: await userAuthenticationCookie.serialize({
-                idToken: "idToken",
-                refreshToken: "refreshToken",
-            }),
+            Cookie: await commitSession(validSession),
         },
         method: "POST",
         body: new URLSearchParams({
@@ -68,6 +80,64 @@ beforeEach(async () => {
     });
     requestWithoutCookie = new Request("https://example.com");
     context = appLoadContext;
+});
+
+describe("loader", () => {
+    test("loader should redirect app page if user is logged in.", async () => {
+        // ローダーを実行し、結果を取得する。
+        const response = await loader({
+            request: requestWithLoggedInUserCookie,
+            params: {},
+            context,
+        });
+
+        // 結果が存在しない場合、エラーを投げる。
+        if (!response) {
+            throw new Error("Response is undefined.");
+        }
+
+        // 検証に必要な情報を取得する。
+        const status = response.status;
+        const location = response.headers.get("Location");
+
+        // 結果を検証する。
+        expect(status).toBe(302);
+        expect(location).toBe("/app");
+    });
+
+    test("loader should redirect login page if user is not logged in.", async () => {
+        // ローダーを実行し、結果を取得する。
+        const response = await loader({
+            request: requestWithoutCookie,
+            params: {},
+            context,
+        });
+
+        // 結果が存在しない場合、エラーを投げる。
+        if (!response) {
+            throw new Error("Response is undefined.");
+        }
+
+        // 検証に必要な情報を取得する。
+        const status = response.status;
+        const location = response.headers.get("Location");
+
+        // 結果を検証する。
+        expect(status).toBe(302);
+        expect(location).toBe("/auth/login");
+    });
+
+    test("loader should return null if user is not registered.", async () => {
+        // ローダーを実行し、結果を取得する。
+        const response = await loader({
+            request: requestWithCookie,
+            params: {},
+            context,
+        });
+
+        // 結果を検証する。
+        expect(response).toBeNull();
+    });
 });
 
 describe("action", () => {
@@ -86,25 +156,6 @@ describe("action", () => {
         // 結果を検証する。
         expect(status).toBe(302);
         expect(location).toBe("/app");
-    });
-
-    test("action should redirect login page if user is not authenticated.", async () => {
-        // アクションを実行し、結果を取得する。
-        const response = await action({
-            request: requestWithoutCookie,
-            params: {},
-            context,
-        });
-
-        // 検証に必要な情報を取得する。
-        const status = response.status;
-        const redirect = response.headers.get("Location");
-        const cookie = await userAuthenticationCookie.parse(response.headers.get("Set-Cookie"));
-
-        // 結果を検証する。
-        expect(status).toBe(302);
-        expect(redirect).toBe("/auth/login");
-        expect(cookie).toStrictEqual({});
     });
 
     test("action should return error message if user can not be registered.", async () => {


### PR DESCRIPTION
## 概要
ユーザー認証でクッキーセッションストレージを使うようにした。
#75 の対応。

## 修正内容
以前まではクッキーに保存したFirebaseのIDトークンを使用し、毎回FirebaseにIDトークンを投げて確認していた。
今回の修正でRemixで提供されているクッキーセッションストレージにユーザーID(profileId)を保存するようにし、ユーザーIDを使ってデータベースからユーザー情報を取得できればログインしているとみなすことにした。
これにより、IDトークンの有効期限が切れてしまい強制的にログアウトしてしまう問題を解決した。

## クッキーセッションストレージの有効期限
30日になる。
有効期限はトップページにアクセスするたび更新されるため、30日以上ログインしない状態が続かない限り、勝手にログアウトされることはない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `.env.example`ファイルに`SESSION_SECRET_KEY`と`TEST_FIREBASE_API_KEY`変数を追加しました。これにより、アプリケーションの設定オプションが拡張されました。
  - セッション管理システムを使用してユーザー認証を行う新しい方法を導入しました。
  - ユーザー登録、ログイン、サインアップのページにメタデータを設定する機能を追加しました。
  - 投稿メッセージと最新の投稿を取得するための新しいセッション管理ロジックを実装しました。

- **バグ修正**
  - ユーザー認証クッキーの使用をセッション管理に置き換え、関連するテストを更新しました。

- **テスト**
  - セッション管理、ユーザー認証、投稿機能のテストケースを追加または更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->